### PR TITLE
First Tile View Version

### DIFF
--- a/src/app/pages/home/Assets/Assets.js
+++ b/src/app/pages/home/Assets/Assets.js
@@ -3,7 +3,7 @@ import React, { useMemo, useState, useEffect } from "react";
 import { shallowEqual, useDispatch, useSelector } from "react-redux";
 import { Formik, setNestedObjectValues } from "formik";
 import { get, merge } from "lodash";
-import { FormHelperText, Switch, Tab, Tabs, Styles } from "@material-ui/core";
+import { FormHelperText, Switch, Tab, Tabs, Styles, Button } from "@material-ui/core";
 import clsx from "clsx";
 import { metronic, initLayoutConfig, LayoutConfig } from "../../../../_metronic";
 import {
@@ -182,6 +182,7 @@ export default function Assets() {
     //
     idCategory: null,
     openCategoriesModal: false,
+    openTileView: false,
     categoryRows: [],
     categories: [],
     categoryRowsSelected: [],
@@ -361,12 +362,15 @@ export default function Assets() {
                         <span className="kt-section__sub">
                           This section will integrate <code>Assets Categories</code>
                         </span>
+                        <Button variant='contained' onClick={() => control.openTileView ? setControl({...control, openTileView: false}):setControl({...control, openTileView: true})} >Tile View</Button>
                         <div className="kt-separator kt-separator--dashed" />
                         <TileView 
-                        tiles={control.categories} 
-                        collection='categories'
-                        onEdit={tableActions('categories').onEdit}
-                        onDelete={tableActions('categories').onDelete}
+                          showTileView={control.openTileView}
+                          tiles={control.categories} 
+                          collection='categories'
+                          onEdit={tableActions('categories').onEdit}
+                          onDelete={tableActions('categories').onDelete}
+                          onReload={() => loadAssetsData('categories')}
                         />
                         { /* <TileView /> */}
                         <ModalAssetCategories

--- a/src/app/pages/home/Assets/Assets.js
+++ b/src/app/pages/home/Assets/Assets.js
@@ -17,6 +17,7 @@ import {
 // AApp Components
 import { TabsTitles } from '../Components/Translations/tabsTitles';
 import TableComponent from '../Components/TableComponent';
+import TileView from '../Components/TileView';
 import ModalAssetCategories from './modals/ModalAssetCategories';
 import ModalAssetReferences from './modals/ModalAssetReferences';
 import ModalAssetList from './modals/ModalAssetList';
@@ -158,10 +159,11 @@ export default function Assets() {
             setControl(prev => ({ ...prev, referenceRows: rows, referenceRowsSelected: [] }));
           }
           if (collectionName === 'categories') {
+            const categoriesInfo = data.response
             const rows = data.response.map(row => {
               return createAssetCategoryRow(row._id, row.name, row.depreciation, 'Admin', '11/03/2020');
             });
-            setControl(prev => ({ ...prev, categoryRows: rows, categoryRowsSelected: [] }));
+            setControl(prev => ({ ...prev, categoryRows: rows, categoryRowsSelected: [], categories: categoriesInfo }));
           }
         })
         .catch(error => console.log('error>', error));
@@ -181,6 +183,7 @@ export default function Assets() {
     idCategory: null,
     openCategoriesModal: false,
     categoryRows: [],
+    categories: [],
     categoryRowsSelected: [],
     //
     idAsset: null,
@@ -358,6 +361,14 @@ export default function Assets() {
                         <span className="kt-section__sub">
                           This section will integrate <code>Assets Categories</code>
                         </span>
+                        <div className="kt-separator kt-separator--dashed" />
+                        <TileView 
+                        tiles={control.categories} 
+                        collection='categories'
+                        onEdit={tableActions('categories').onEdit}
+                        onDelete={tableActions('categories').onDelete}
+                        />
+                        { /* <TileView /> */}
                         <ModalAssetCategories
                           // showModal={openCategoriesModal}
                           // setShowModal={setOpenCategoriesModal}

--- a/src/app/pages/home/Assets/modals/ModalAssetCategories.js
+++ b/src/app/pages/home/Assets/modals/ModalAssetCategories.js
@@ -180,6 +180,7 @@ const ModalAssetCategories = ({ showModal, setShowModal, reloadTable, id }) => {
   };
 
   const handleCloseModal = () => {
+    setImage(null);
     setCustomFieldsTab({});
     setValues({ 
       name: "",

--- a/src/app/pages/home/Components/ImageUpload.js
+++ b/src/app/pages/home/Components/ImageUpload.js
@@ -21,7 +21,7 @@ const ImageUpload = ({ children, setImage = () => {}, image = null }) => {
   useEffect(() => {
     setValues({
       ...values,
-      categoryPic: image || values.categoryPicDefault
+      categoryPic: image? `${image}?${new Date()}` : values.categoryPicDefault
     });
   }, [image]);
 

--- a/src/app/pages/home/Components/TileView.js
+++ b/src/app/pages/home/Components/TileView.js
@@ -11,16 +11,16 @@ const useStyles = makeStyles((theme) => ({
     overflow: 'auto',
     backgroundColor: theme.palette.background.paper,
     width: '100%',
-    height: 400,
+    maxHeight: 400,
   },
   container: {
     display: 'flex',
     flexWrap: 'wrap',
   },
   tile: {
-    margin: 1,
+    margin: 2,
     position: 'relative',
-    borderWidth: 0.5,
+    borderWidth: 1,
     borderStyle: 'solid',
     borderColor: '#BCBCBC',
     '&:hover': {
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme) => ({
       cursor: 'pointer',
       borderWidth: 2,
     },
-    zIndex: 0,
+    zIndex: 3,
   },
   optionsNotShow: {
     display: 'flex',
@@ -84,87 +84,89 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-const TileView = ({ tiles, collection, tailWidth = '120px', tailHeight = '120px', onEdit, onDelete }) => {
+const TileView = ({ tiles, collection, tailWidth = '120px', tailHeight = '120px', onEdit, onDelete, onReload, showTileView }) => {
   const classes = useStyles();
-  const [open, setopen] = useState(false)
   const [selectedId, setSelectedId] = useState([])
-  const [openYesNoModal, setOpenYesNoModal] = useState(false);
+  const [openYesNoModal, setOpenYesNoModal] = useState([false, []]);
 
-  const showTileView = () => open ? setopen(false) : setopen(true)
   const onTileHover = (id) => {
     if (id) {
       setSelectedId([id])
     }
+    else {
+      setSelectedId([])
+    }
   }
 
   const confirmDelete = () => {
-    onDelete(selectedId)
-    setOpenYesNoModal(false)
+    onDelete(openYesNoModal[1])
+    setOpenYesNoModal([false, []])
+    onReload()
     setSelectedId([])
   }
-
+  
+  
   return (
-    <div className={classes.root}>
-      <ModalYesNo
-        showModal={openYesNoModal}
-        onOK={() => confirmDelete()}
-        onCancel={() => setOpenYesNoModal(false)}
-        title={'Remove Element'}
-        message={'Are you sure you want to remove this element?'}
-      />
-      <Collapse in={open}>
-        <div className={classes.container}>
-          {tiles.map((tile) => {
-            const imageURL = getImageURL(tile._id, collection, tile.fileExt)
-            return (
-              <div 
-                className={classes.tile} 
-                style={{ width: tailWidth, height: tailHeight }} 
-                onMouseEnter={() => onTileHover(tile._id)} 
-                onMouseLeave={() => onTileHover(null)} 
-                key={tile._id}
-              >
-                <img 
-                  src={imageURL ? imageURL : 'http://localhost:3000/media/misc/placeholder-image.jpg'} 
-                  width='100%' 
-                  height='100%' 
-                  className={classes.image} 
-                  alt='Categories' 
-                />
-                {
-                  tile._id === selectedId[0] ?
-                    <div className={classes.optionsShow}>
-                      <div className={classes.buttonsContainer}>
-                        <IconButton size='small' className={classes.iconButton} onClick={() => onEdit(selectedId)}>
-                          <EditIcon fontSize='small' />
-                        </IconButton>
-                        <IconButton size='small' color='grey' className={classes.iconButton} onClick={() => setOpenYesNoModal(true)}>
-                          <DeleteIcon fontSize='small' />
-                        </IconButton>
-                      </div>
-                      <div className={classes.textContainer}>
-                        <div className={classes.text}>
-                          <Typography noWrap={true}>{tile.name}</Typography>
+    <Collapse in={showTileView}>
+      <div className={classes.root}>
+        <ModalYesNo
+          showModal={openYesNoModal[0]}
+          onOK={() => confirmDelete()}
+          onCancel={() => setOpenYesNoModal([false, []])}
+          title={'Remove Element'}
+          message={'Are you sure you want to remove this element?'}
+        />
+          <div className={classes.container}>
+            {tiles.map((tile) => {
+              const imageURL = getImageURL(tile._id, collection, tile.fileExt)
+              return (
+                <div 
+                  className={classes.tile} 
+                  style={{ width: tailWidth, height: tailHeight }} 
+                  onMouseEnter={() => onTileHover(tile._id)} 
+                  onMouseLeave={() => onTileHover(null)} 
+                  key={tile._id}
+                >
+                  <img 
+                    src={imageURL ? `${imageURL}?${new Date()}` : 'http://localhost:3000/media/misc/placeholder-image.jpg'} 
+                    width='100%' 
+                    height='100%' 
+                    className={classes.image} 
+                    alt='Categories' 
+                  />
+                  {
+                    tile._id === selectedId[0] ?
+                      <div className={classes.optionsShow}>
+                        <div className={classes.buttonsContainer}>
+                          <IconButton size='small' className={classes.iconButton} onClick={() => onEdit(selectedId)}>
+                            <EditIcon fontSize='small' />
+                          </IconButton>
+                          <IconButton size='small' color='grey' className={classes.iconButton} onClick={() => setOpenYesNoModal([true, [selectedId]])}>
+                            <DeleteIcon fontSize='small' />
+                          </IconButton>
+                        </div>
+                        <div className={classes.textContainer}>
+                          <div className={classes.text}>
+                            <Typography noWrap={true}>{tile.name}</Typography>
+                          </div>
                         </div>
                       </div>
-                    </div>
-                    :
-                    <div className={classes.optionsNotShow}>
-                      <div className={classes.textContainer}>
-                        <div className={classes.text}>
-                          <Typography noWrap={true}>{tile.name}</Typography>
+                      :
+                      <div className={classes.optionsNotShow}>
+                        <div className={classes.textContainer}>
+                          <div className={classes.text}>
+                            <Typography noWrap={true}>{tile.name}</Typography>
+                          </div>
                         </div>
                       </div>
-                    </div>
-                }
-              </div>
-            )
-          }
-          )}
-        </div>
-      </Collapse>
-      <Button variant='contained' onClick={() => showTileView()} className={classes.button}>Tile View</Button>
-    </div>
+                  }
+                </div>
+              )
+            }
+            )}
+          </div>
+      </div>
+    </Collapse>
   )
 }
 

--- a/src/app/pages/home/Components/TileView.js
+++ b/src/app/pages/home/Components/TileView.js
@@ -1,0 +1,171 @@
+import React, { useState, useEffect } from 'react';
+import { makeStyles, Typography, Button, Collapse, IconButton } from '@material-ui/core';
+import EditIcon from '@material-ui/icons/Edit';
+import DeleteIcon from '@material-ui/icons/Delete';
+
+import ModalYesNo from '../Components/ModalYesNo';
+import { getImageURL } from '../utils';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    overflow: 'auto',
+    backgroundColor: theme.palette.background.paper,
+    width: '100%',
+    height: 400,
+  },
+  container: {
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  tile: {
+    margin: 1,
+    position: 'relative',
+    borderWidth: 0.5,
+    borderStyle: 'solid',
+    borderColor: '#BCBCBC',
+    '&:hover': {
+      borderColor: '#0061A699',
+      cursor: 'pointer',
+      borderWidth: 2,
+    },
+    zIndex: 0,
+  },
+  optionsNotShow: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'flex-end',
+    width: '100%',
+    height: '100%',
+  },
+  optionsShow: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    width: '100%',
+    height: '100%',
+  },
+  textContainer: {
+    zIndex: 2,
+    backgroundColor: '#00000099',
+    width: '100%',
+    height: '20%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  buttonsContainer: {
+    zIndex: 2,
+    padding: 4,
+    borderBottomLeftRadius: 12,
+    backgroundColor: '#8e8b8b99',
+    alignSelf: 'flex-end',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '80%',
+    height: '80%',
+    color: 'white',
+    padding: 1,
+  },
+  image: {
+    zIndex: 1,
+    position: 'absolute'
+  },
+  button: {
+    marginTop: 20,
+  },
+  iconButton: {
+    margin: 2,
+  }
+}));
+
+const TileView = ({ tiles, collection, tailWidth = '120px', tailHeight = '120px', onEdit, onDelete }) => {
+  const classes = useStyles();
+  const [open, setopen] = useState(false)
+  const [selectedId, setSelectedId] = useState([])
+  const [openYesNoModal, setOpenYesNoModal] = useState(false);
+
+  const showTileView = () => open ? setopen(false) : setopen(true)
+  const onTileHover = (id) => {
+    if (id) {
+      setSelectedId([id])
+    }
+  }
+
+  const confirmDelete = () => {
+    onDelete(selectedId)
+    setOpenYesNoModal(false)
+    setSelectedId([])
+  }
+
+  return (
+    <div className={classes.root}>
+      <ModalYesNo
+        showModal={openYesNoModal}
+        onOK={() => confirmDelete()}
+        onCancel={() => setOpenYesNoModal(false)}
+        title={'Remove Element'}
+        message={'Are you sure you want to remove this element?'}
+      />
+      <Collapse in={open}>
+        <div className={classes.container}>
+          {tiles.map((tile) => {
+            const imageURL = getImageURL(tile._id, collection, tile.fileExt)
+            return (
+              <div 
+                className={classes.tile} 
+                style={{ width: tailWidth, height: tailHeight }} 
+                onMouseEnter={() => onTileHover(tile._id)} 
+                onMouseLeave={() => onTileHover(null)} 
+                key={tile._id}
+              >
+                <img 
+                  src={imageURL ? imageURL : 'http://localhost:3000/media/misc/placeholder-image.jpg'} 
+                  width='100%' 
+                  height='100%' 
+                  className={classes.image} 
+                  alt='Categories' 
+                />
+                {
+                  tile._id === selectedId[0] ?
+                    <div className={classes.optionsShow}>
+                      <div className={classes.buttonsContainer}>
+                        <IconButton size='small' className={classes.iconButton} onClick={() => onEdit(selectedId)}>
+                          <EditIcon fontSize='small' />
+                        </IconButton>
+                        <IconButton size='small' color='grey' className={classes.iconButton} onClick={() => setOpenYesNoModal(true)}>
+                          <DeleteIcon fontSize='small' />
+                        </IconButton>
+                      </div>
+                      <div className={classes.textContainer}>
+                        <div className={classes.text}>
+                          <Typography noWrap={true}>{tile.name}</Typography>
+                        </div>
+                      </div>
+                    </div>
+                    :
+                    <div className={classes.optionsNotShow}>
+                      <div className={classes.textContainer}>
+                        <div className={classes.text}>
+                          <Typography noWrap={true}>{tile.name}</Typography>
+                        </div>
+                      </div>
+                    </div>
+                }
+              </div>
+            )
+          }
+          )}
+        </div>
+      </Collapse>
+      <Button variant='contained' onClick={() => showTileView()} className={classes.button}>Tile View</Button>
+    </div>
+  )
+}
+
+export default TileView


### PR DESCRIPTION
- Created First Tile View Version
- `on hover` shows Edit and Delete buttons
- Edit and Delete Buttons show it's corresponding modal and work properly

~~*Current Bug:* Hovering over a tile shows Edit and Delete icons but the icons stay there even when you stop hovering the tile. This bug was already fixed on local, but I'm waiting on other corrections before pushing a new commit.~~

*Update:*
- The `TileView'` _On Hovering_ bug was fixed
- There was a bug, where components didn't show the correct image when it was updated. Wich has been fixed on both `TileView` and `ModalAssetsCategories`.

There's still a bug in the `ModalAssetsCategories` component, but as it's not part of this ticket, it will be fixed in the future:

- When we edit an object but we don't change its picture, the modal will remove the `fileExt` as if that object had no image, even though it had one before editing.
