### PR TITLE
Language Changed on Settings and Inactivity is now working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13115,6 +13115,11 @@
         }
       }
     },
+    "react-idle-timer": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/react-idle-timer/-/react-idle-timer-4.5.6.tgz",
+      "integrity": "sha512-7+sdN78SWu2vZpQsPWDbrgfZWkSqzzXeq5/bC3wvlRLj6xVTA1fA+8Qy0vJmNONz5UXu8Ymrj6rn6DFhcxgssg=="
+    },
     "react-image-marker": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/react-image-marker/-/react-image-marker-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react-draggable": "^4.1.0",
     "react-helmet": "^5.2.1",
     "react-highlight": "^0.12.0",
+    "react-idle-timer": "^4.5.6",
     "react-image-marker": "^1.2.0",
     "react-intl": "^3.6.2",
     "react-is": "^16.12.0",

--- a/src/App.js
+++ b/src/App.js
@@ -2,15 +2,45 @@
  * Entry application component used to compose providers and render Routes.
  * */
 
-import React, { Suspense } from "react";
+import React, { Suspense, useEffect, useState } from "react";
 import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
 import { PersistGate } from "redux-persist/integration/react";
 import { LastLocationProvider } from "react-router-last-location";
+import { useIdleTimer } from "react-idle-timer";
 import { Routes } from "./app/router/Routes";
 import { I18nProvider, LayoutSplashScreen, ThemeProvider } from "./_metronic";
+import { getDB } from './app/crud/api';
 
 export default function App({ store, persistor, basename }) {
+  const [logoutPreferences, setlogoutPreferences] = useState({
+    inactivityPeriod: 600000,
+    selectedInactivity: 0
+  })
+
+  const handleIdle = () => {
+    const hrefSplitted = window.location.href.split('/')
+    if (hrefSplitted[hrefSplitted.length - 1] !== 'login' && logoutPreferences.selectedInactivity === 1) {
+      window.location.replace('/logout')
+    }
+  }
+
+  useEffect(() => {
+    getDB('settingsGeneral')
+      .then(response => response.json())
+      .then(data => {
+        const { inactivityPeriod, selectedInactivity } = data.response[0];
+        setlogoutPreferences({inactivityPeriod, selectedInactivity})
+      })
+      .catch(error => console.log('error>', error));
+  }, [])
+
+  useIdleTimer({
+    timeout: logoutPreferences.inactivityPeriod,
+    onActive: () => { },
+    onIdle: () => handleIdle(),
+  });
+
   return (
     /* Provide Redux store */
     <Provider store={store}>

--- a/src/app/pages/home/Settings/settings-tabs/General.jsx
+++ b/src/app/pages/home/Settings/settings-tabs/General.jsx
@@ -1,27 +1,32 @@
 /* eslint-disable no-restricted-imports */
 import React, { useEffect, useState } from 'react';
 import { omit, isEmpty } from 'lodash';
-import { getDB, postDB, getOneDB, updateDB } from '../../../../crud/api';
+import { connect } from "react-redux";
+import { getDB, postDB, updateDB } from '../../../../crud/api';
+import { metronic } from "../../../../../_metronic";
+import { getFirstDocCollection } from '../../utils';
+import { languages } from '../../constants';
 import SaveButton from '../settings-tabs/components/SaveButton';
-import { getFileExtension, saveImage, getImageURL, getFirstDocCollection } from '../../utils';
 
 import {
   FormControl,
   InputLabel,
   Select,
-  MenuItem
+  MenuItem,
+  TextField
 } from "@material-ui/core";
 import { useStyles } from './styles';
 
 const General = props => {
   const classes = useStyles();
   const [values, setValues] = useState({
-    languages: [{ id: 'en', name: 'English' }, { id: 'es', name: 'Español' }],
+    languages: languages,
     currencies: [{ id: 'usd', name: 'American Dollar' }, { id: 'mxn', name: 'Mexican Peso' }],
-    inactivity: [{ id: 'in0', name: 'Do nothing' }, { id: 'in1', name: 'Logout (10 min)' }],
-    selectedLanguage: '',
-    selectedCurrency: '',
-    selectedInactivity: ''
+    inactivity: [{ id: 'in0', name: 'Do nothing' }, { id: 'in1', name: 'Logout' }],
+    selectedLanguage: props.lang,
+    selectedCurrency: 1,
+    selectedInactivity: 0,
+    inactivityPeriod: 60000
   });
   const fields = [
     { id: 'languages', name: 'Language', selected: 'selectedLanguage' },
@@ -29,7 +34,7 @@ const General = props => {
     { id: 'inactivity', name: 'Inactivity', selected: 'selectedInactivity' }
   ];
   const handleChange = name => event => {
-    setValues({ ...values, [name]: event.target.value });
+    setValues({ ...values, [name]: name === 'inactivityPeriod' ? Number(event.target.value * 60000) : event.target.value });
   };
   const handleSave = () => {
     const body = { ...values };
@@ -40,6 +45,7 @@ const General = props => {
             .then(data => data.json())
             .then(response => {
               // saveImages(imagesInfo);
+              window.location.reload()
             })
             .catch(error => console.log(error));
         } else {
@@ -47,24 +53,25 @@ const General = props => {
             .then(response => {
               // saveImages(imagesInfo);
               // saveAndReload('settingsDesign', 'logoLogin');
+              window.location.reload()
             })
             .catch(error => console.log(error));
         }
       })
-      .catch(ex => {});
+      .catch(ex => { });
   };
 
   const loadProcessesData = (collectionName = 'settingsGeneral') => {
     getDB(collectionName)
-    .then(response => response.json())
-    .then(data => {
-      const _values = data.response[0] || {};
-      console.log('_values:', _values)
-      if (!isEmpty(_values)) {
-        setValues(omit(_values, '_id'));
-      }
-    })
-    .catch(error => console.log('error>', error));
+      .then(response => response.json())
+      .then(data => {
+        const _values = data.response[0] || {};
+        console.log('_values:', _values)
+        if (!isEmpty(_values)) {
+          setValues(omit(_values, '_id'));
+        }
+      })
+      .catch(error => console.log('error>', error));
   };
 
   useEffect(() => {
@@ -73,10 +80,10 @@ const General = props => {
 
   return (
     <div>
-      <div style={{textAlign: 'end', marginBottom: '15px'}}>
-        <SaveButton handleOnClick={handleSave}/>
+      <div style={{ textAlign: 'end', marginBottom: '15px' }}>
+        <SaveButton handleOnClick={handleSave} />
       </div>
-      {fields.map(({id, name, selected}, ix) => (
+      {fields.map(({ id, name, selected }, ix) => (
         <FormControl key={`base-field-${ix}`} className={classes.textField}>
           <InputLabel htmlFor="age-simple">{name}</InputLabel>
           <Select
@@ -89,8 +96,27 @@ const General = props => {
           </Select>
         </FormControl>
       ))}
+      {
+        values.selectedInactivity === 1 && (
+          <FormControl className={classes.textField}>
+            <TextField
+              type='number'
+              label='Minutes idle before Logout'
+              onChange={handleChange('inactivityPeriod')}
+              value={Math.trunc(values.inactivityPeriod / 60000)}
+              inputProps={{
+                min: 1
+              }}
+            />
+          </FormControl>
+        )
+      }
     </div>
   );
 }
 
-export default General;
+const mapStateToProps = ({ i18n }) => ({ lang: i18n.lang });
+export default connect(
+  mapStateToProps,
+  metronic.i18n.actions
+)(General);

--- a/src/app/pages/home/constants.js
+++ b/src/app/pages/home/constants.js
@@ -1,3 +1,5 @@
+import { toAbsoluteUrl } from "../../../_metronic";
+
 export const modules = [
   { key: 'dashboard', name: 'Dashboard' },
   { key: 'assets', name: 'Assets' },
@@ -87,3 +89,16 @@ export const allBaseFields = {
     labelingDate: { validationId: 'labelingDate', component: 'textField', compLabel: 'Labeling Date' },
   },
 };
+
+export const languages = [
+  {
+    lang: "en",
+    name: "English",
+    flag: toAbsoluteUrl("/media/flags/226-united-states.svg")
+  },
+  {
+    lang: "es",
+    name: "Spanish",
+    flag: toAbsoluteUrl("/media/flags/252-mexico.svg")
+  },
+];

--- a/src/app/partials/layout/LanguageSelector.js
+++ b/src/app/partials/layout/LanguageSelector.js
@@ -2,22 +2,9 @@ import React from "react";
 import clsx from "clsx";
 import { connect } from "react-redux";
 import { Dropdown } from "react-bootstrap";
-import { metronic, toAbsoluteUrl } from "../../../_metronic";
+import { metronic } from "../../../_metronic";
 import HeaderDropdownToggle from "../content/CustomDropdowns/HeaderDropdownToggle";
-
-const languages = [
-  {
-    lang: "en",
-    name: "English",
-    flag: toAbsoluteUrl("/media/flags/226-united-states.svg")
-  },
-  {
-    lang: "es",
-    name: "Spanish",
-    flag: toAbsoluteUrl("/media/flags/252-mexico.svg")
-  },
-];
-
+import { languages } from "../../pages/home/constants";
 class LanguageSelector extends React.Component {
   render() {
     const { lang, iconType, setLanguage } = this.props;
@@ -49,7 +36,7 @@ class LanguageSelector extends React.Component {
                   onClick={() => {
                     setLanguage(language.lang);
                     this.setState({ open: false });
-                    setTimeout(()=> window.location.reload(), 400);
+                    setTimeout(() => window.location.reload(), 400);
                   }}
                   className={clsx("kt-nav__link", {
                     "kt-nav__link--active":


### PR DESCRIPTION
- Language functionality on `Settings General` was changed.
- A new package was added to handle inactivity: `react-idle-timer`.
- The inactivity functionality is linked to `Settings General` and will function as expected. 
- The user can select whether to do nothing or to log out when the user is inactive. 
- A dynamic text field was added to `Settings General`, it will only show itself when the user selects to log out allowing him to set the time required to consider the user as inactive.