### PR TITLE
Creation information on tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5352,6 +5352,11 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.9.0.tgz",
       "integrity": "sha512-khbFLu/MlzLjEzy9Gh8oY1hNt/Dvxw3J6Rbc28cVoYWQaC1S3YI4xwkF9ZWcjDLscbZlY9hISMr66RFzZagLsA=="
     },
+    "date-fns-tz": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.1.4.tgz",
+      "integrity": "sha512-lQ+FF7xUxxRuRqIY7H/lagnT3PhhSnnvtGHzjE5WZKwRyLU7glJfLys05SZ7zHlEr6RXWiqkmgWq4nCkcElR+g=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "cp-cli": "^2.0.0",
     "css-mediaquery": "^0.1.2",
     "date-fns": "^2.8.1",
+    "date-fns-tz": "^1.1.4",
     "dentist": "^1.0.3",
     "dotenv": "^8.2.0",
     "downshift": "^3.4.2",

--- a/src/app/pages/home/Assets/Assets.js
+++ b/src/app/pages/home/Assets/Assets.js
@@ -9,6 +9,7 @@ import {
   PortletHeaderToolbar
 } from '../../../partials/content/Portlet';
 
+import { utcToZonedTime } from 'date-fns-tz';
 import LanguageIcon from '@material-ui/icons/Language';
 import CheckIcon from '@material-ui/icons/Check';
 import BuildIcon from '@material-ui/icons/Build';
@@ -156,21 +157,21 @@ function Assets({ globalSearch, setGeneralSearch, showDeletedAlert, showErrorAle
         .then(data => {
           if (collectionName === 'assets') {
             const rows = data.response.map(row => {
-              const creationDate = new Date(row.creationDate).toLocaleString();
+              const creationDate = utcToZonedTime(row.creationDate).toLocaleString();
               return createAssetListRow(row._id, row.name, row.brand, row.model, row.category, row.serial, row.EPC, row.creationUserFullName, creationDate, row.location);
             });
             setControl(prev => ({ ...prev, assetRows: rows, assetRowsSelected: [] }));
           }
           if (collectionName === 'references') {
             const rows = data.response.map(row => {
-              const creationDate = new Date(row.creationDate).toLocaleString();
+              const creationDate = utcToZonedTime(row.creationDate).toLocaleString();
               return createAssetReferenceRow(row._id, row.name, row.brand, row.model, row.category, row.creationUserFullName, creationDate, row.price);
             });
             setControl(prev => ({ ...prev, referenceRows: rows, referenceRowsSelected: [] }));
           }
           if (collectionName === 'categories') {
             const rows = data.response.map(row => {
-              const creationDate = new Date(row.creationDate).toLocaleString();
+              const creationDate = utcToZonedTime(row.creationDate).toLocaleString();
               return createAssetCategoryRow(row._id, row.name, row.depreciation, row.creationUserFullName, creationDate, row.fileExt);
             });
             setControl(prev => ({ ...prev, categoryRows: rows, categoryRowsSelected: [] }));

--- a/src/app/pages/home/Assets/Assets.js
+++ b/src/app/pages/home/Assets/Assets.js
@@ -156,19 +156,22 @@ function Assets({ globalSearch, setGeneralSearch, showDeletedAlert, showErrorAle
         .then(data => {
           if (collectionName === 'assets') {
             const rows = data.response.map(row => {
-              return createAssetListRow(row._id, row.name, row.brand, row.model, row.category, row.serial, row.EPC, 'Admin', '11/03/2020', row.location);
+              const creationDate = new Date(row.creationDate).toLocaleString();
+              return createAssetListRow(row._id, row.name, row.brand, row.model, row.category, row.serial, row.EPC, row.creationUserFullName, creationDate, row.location);
             });
             setControl(prev => ({ ...prev, assetRows: rows, assetRowsSelected: [] }));
           }
           if (collectionName === 'references') {
             const rows = data.response.map(row => {
-              return createAssetReferenceRow(row._id, row.name, row.brand, row.model, row.category, 'Admin', '11/03/2020', row.price);
+              const creationDate = new Date(row.creationDate).toLocaleString();
+              return createAssetReferenceRow(row._id, row.name, row.brand, row.model, row.category, row.creationUserFullName, creationDate, row.price);
             });
             setControl(prev => ({ ...prev, referenceRows: rows, referenceRowsSelected: [] }));
           }
           if (collectionName === 'categories') {
             const rows = data.response.map(row => {
-              return createAssetCategoryRow(row._id, row.name, row.depreciation, 'Admin', '11/03/2020', row.fileExt);
+              const creationDate = new Date(row.creationDate).toLocaleString();
+              return createAssetCategoryRow(row._id, row.name, row.depreciation, row.creationUserFullName, creationDate, row.fileExt);
             });
             setControl(prev => ({ ...prev, categoryRows: rows, categoryRowsSelected: [] }));
           }

--- a/src/app/pages/home/Components/Policies/components/PoliciesTable.jsx
+++ b/src/app/pages/home/Components/Policies/components/PoliciesTable.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { utcToZonedTime } from 'date-fns-tz';
 import {
   PortletBody,
 } from '../../../../../partials/content/Portlet';
@@ -172,7 +173,7 @@ const PoliciesTable = ({ module }) => {
                 creationUserFullName,
                 creationDate,
               } = row;
-              const date = new Date(creationDate).toString();
+              const date = utcToZonedTime(creationDate).toLocaleString();
               const typeString = getTypeString(
                 messageDisabled,
                 notificationDisabled,

--- a/src/app/pages/home/Components/Policies/components/PoliciesTable.jsx
+++ b/src/app/pages/home/Components/Policies/components/PoliciesTable.jsx
@@ -168,8 +168,11 @@ const PoliciesTable = ({ module }) => {
                 notificationDisabled,
                 policyName,
                 selectedAction,
-                selectedCatalogue
+                selectedCatalogue,
+                creationUserFullName,
+                creationDate,
               } = row;
+              const date = new Date(creationDate).toString();
               const typeString = getTypeString(
                 messageDisabled,
                 notificationDisabled,
@@ -181,8 +184,8 @@ const PoliciesTable = ({ module }) => {
                 selectedCatalogue,
                 selectedAction,
                 typeString,
-                'Admin',
-                '12/2/2020'
+                creationUserFullName,
+                date
               );
             });
             setControl((prev) => ({

--- a/src/app/pages/home/Employees/Employees.js
+++ b/src/app/pages/home/Employees/Employees.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from "react-redux";
+import { utcToZonedTime } from 'date-fns-tz';
 import { Tabs } from '@material-ui/core';
 import { useDispatch } from 'react-redux';
 import { actions } from '../../../store/ducks/general.duck';
@@ -139,11 +140,12 @@ const Employees = ({ globalSearch, setGeneralSearch }) => {
           if (collectionName === 'employeeProfiles') {
             const rows = data.response.map((row) => {
               const { _id, name, creationUserFullName, creationDate } = row;
+              const date = utcToZonedTime(creationDate).toLocaleString();
               return createUserProfilesRow(
                 _id,
                 name,
                 creationUserFullName,
-                creationDate
+                date
               );
             });
             setControl(prev => ({ ...prev, employeeProfilesRows: rows, employeeProfilesRowsSelected: [] }));
@@ -151,6 +153,7 @@ const Employees = ({ globalSearch, setGeneralSearch }) => {
           if (collectionName === 'employees') {
             const rows = data.response.map((row) => {
               const { _id, name, lastName, email, designation, manager, creationUserFullName, creationDate } = row;
+              const date = utcToZonedTime(creationDate).toLocaleString();
               return createEmployeeRow(
                 _id,
                 name,
@@ -159,7 +162,7 @@ const Employees = ({ globalSearch, setGeneralSearch }) => {
                 designation,
                 manager,
                 creationUserFullName,
-                creationDate
+                date
               );
             });
             setControl(prev => ({ ...prev, usersRows: rows, usersRowsSelected: [] }));

--- a/src/app/pages/home/Help/components/MyTickets.jsx
+++ b/src/app/pages/home/Help/components/MyTickets.jsx
@@ -117,14 +117,15 @@ const MyTickets = () => {
         .then((data) => {
           if (collectionName === "tickets") {
             const rows = data.response.map((row) => {
-              const { _id, message, peaceOfMind, selectedType, subject } = row;
+              const { _id, message, peaceOfMind, selectedType, subject, creationUserFullName, creationDate } = row;
+              const date = new Date(creationDate).toString();
               return createTicketsRow(
                 _id,
                 subject,
                 selectedType,
                 peaceOfMind,
-                "Admin",
-                "11/03/2020"
+                creationUserFullName,
+                date
               );
             });
             setControl((prev) => ({

--- a/src/app/pages/home/Help/components/MyTickets.jsx
+++ b/src/app/pages/home/Help/components/MyTickets.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { utcToZonedTime } from 'date-fns-tz';
 import {
   Portlet,
   PortletBody,
@@ -118,7 +119,7 @@ const MyTickets = () => {
           if (collectionName === "tickets") {
             const rows = data.response.map((row) => {
               const { _id, message, peaceOfMind, selectedType, subject, creationUserFullName, creationDate } = row;
-              const date = new Date(creationDate).toString();
+              const date = utcToZonedTime(creationDate).toLocaleString();
               return createTicketsRow(
                 _id,
                 subject,

--- a/src/app/pages/home/Locations/Locations.js
+++ b/src/app/pages/home/Locations/Locations.js
@@ -420,8 +420,9 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
         .then(data => {
           if (collectionName === 'locations') {
             const profileRows = data.response.map((row) => {
-              const { _id, level, name } = row;
-              return createLocationProfileRow(_id, level, name, 'Admin', '11/03/2020');
+              const { _id, level, name, creationUserFullName, creationDate } = row;
+              const date = new Date(creationDate).toString();
+              return createLocationProfileRow(_id, level, name, creationUserFullName, date);
             });
             setLocationProfileRows(profileRows);
             setSelectedLocationProfileRows([]);

--- a/src/app/pages/home/Locations/Locations.js
+++ b/src/app/pages/home/Locations/Locations.js
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import ImageMarker from 'react-image-marker';
 import SwipeableViews from 'react-swipeable-views';
+import { utcToZonedTime } from 'date-fns-tz';
 import { merge } from 'lodash';
 import { Formik } from 'formik';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
@@ -421,7 +422,7 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
           if (collectionName === 'locations') {
             const profileRows = data.response.map((row) => {
               const { _id, level, name, creationUserFullName, creationDate } = row;
-              const date = new Date(creationDate).toString();
+              const date = utcToZonedTime(creationDate).toLocaleString();
               return createLocationProfileRow(_id, level, name, creationUserFullName, date);
             });
             setLocationProfileRows(profileRows);

--- a/src/app/pages/home/Processes/Processes.js
+++ b/src/app/pages/home/Processes/Processes.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { utcToZonedTime } from 'date-fns-tz';
 import { isEmpty } from 'lodash';
 import { Tabs } from '@material-ui/core';
 import { actions } from '../../../store/ducks/general.duck';
@@ -132,14 +133,14 @@ export default function Processes() {
             const rows = data.response.map(row => {
               const { functions, selectedFunction, types, selectedType, customFieldTabs, creationUserFullName, creationDate } = row;
               const isCustom = String(!isEmpty(customFieldTabs)).toUpperCase();
-              const date = new Date(creationDate).toString();
+              const date = utcToZonedTime(creationDate).toLocaleString();
               return createProcessStageRow(row._id, row.name, functions[selectedFunction], types[selectedType], isCustom, 'FALSE', creationUserFullName, date);
             });
             setControl(prev => ({ ...prev, processStagesRows: rows, processStagesRowsSelected: [] }));
           }
           if (collectionName === 'processes') {
             const rows = data.response.map(row => {
-              const date = new Date(row.creationDate).toString();
+              const date = utcToZonedTime(row.creationDate).toLocaleString();
               return createProcessRow(row._id, row.name, row.processStages.length || 'N/A', row.creationUserFullName, date);
             });
             setControl(prev => ({ ...prev, processRows: rows, processRowsSelected: [] }));

--- a/src/app/pages/home/Processes/Processes.js
+++ b/src/app/pages/home/Processes/Processes.js
@@ -130,15 +130,17 @@ export default function Processes() {
         .then(data => {
           if (collectionName === 'processStages') {
             const rows = data.response.map(row => {
-              const { functions, selectedFunction, types, selectedType, customFieldTabs } = row;
+              const { functions, selectedFunction, types, selectedType, customFieldTabs, creationUserFullName, creationDate } = row;
               const isCustom = String(!isEmpty(customFieldTabs)).toUpperCase();
-              return createProcessStageRow(row._id, row.name, functions[selectedFunction], types[selectedType], isCustom, 'FALSE', 'Admin', '11/03/2020');
+              const date = new Date(creationDate).toString();
+              return createProcessStageRow(row._id, row.name, functions[selectedFunction], types[selectedType], isCustom, 'FALSE', creationUserFullName, date);
             });
             setControl(prev => ({ ...prev, processStagesRows: rows, processStagesRowsSelected: [] }));
           }
           if (collectionName === 'processes') {
             const rows = data.response.map(row => {
-              return createProcessRow(row._id, row.name, row.processStages.length || 'N/A', 'Admin', '11/03/2020');
+              const date = new Date(row.creationDate).toString();
+              return createProcessRow(row._id, row.name, row.processStages.length || 'N/A', row.creationUserFullName, date);
             });
             setControl(prev => ({ ...prev, processRows: rows, processRowsSelected: [] }));
           }

--- a/src/app/pages/home/Processes/components/LiveProcesses.jsx
+++ b/src/app/pages/home/Processes/components/LiveProcesses.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import React, { useState, useEffect } from 'react';
+import { utcToZonedTime } from 'date-fns-tz';
 import { Tab, Tabs } from "@material-ui/core";
 import { getDB, postDB, getOneDB, updateDB, deleteDB } from '../../../../crud/api';
 import {
@@ -118,7 +119,7 @@ const LiveProcesses = (props) => {
       .then(data => {
         const rows = data.response.map(row => {
           const { _id: id, processData: { name, processStages }, creationUserFullName, creationDate } = row;
-          const date = new Date(creationDate).toString();
+          const date = utcToZonedTime(creationDate).toLocaleString();
           return createLiveProcessesHeadRows(id, id.slice(-6), name, 'Type', '12/12/12', 'Approvals', processStages.length, creationUserFullName, date);
         });
         setControl(prev => ({ ...prev, processLiveRows: rows, ProcessLiveRowsSelected: [] }));

--- a/src/app/pages/home/Processes/components/LiveProcesses.jsx
+++ b/src/app/pages/home/Processes/components/LiveProcesses.jsx
@@ -117,10 +117,9 @@ const LiveProcesses = (props) => {
       .then(response => response.json())
       .then(data => {
         const rows = data.response.map(row => {
-          const { _id: id, processData: { name, processStages } } = row;
-          return createLiveProcessesHeadRows(id, id.slice(-6), name, 'Type', '12/12/12', 'Approvals', processStages.length, 'Admin', '11/03/2020');
-          // return { id, folio, name, type, date, approvals, status, creator, creation_date };
-          // return createLayoutsEmployeeRow(row._id, row.name, 99, 'Admin', '11/03/2020');
+          const { _id: id, processData: { name, processStages }, creationUserFullName, creationDate } = row;
+          const date = new Date(creationDate).toString();
+          return createLiveProcessesHeadRows(id, id.slice(-6), name, 'Type', '12/12/12', 'Approvals', processStages.length, creationUserFullName, date);
         });
         setControl(prev => ({ ...prev, processLiveRows: rows, ProcessLiveRowsSelected: [] }));
       })

--- a/src/app/pages/home/Reports/Reports.js
+++ b/src/app/pages/home/Reports/Reports.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { shallowEqual, useSelector } from "react-redux";
+import { utcToZonedTime } from 'date-fns-tz';
 import { Tabs } from "@material-ui/core";
 import {
   Portlet,
@@ -136,7 +137,7 @@ const Reports = () => {
           const rows = data.response.map((row) => {
             const { _id, selectReport, reportName, enabled, creationUserFullName, creationDate } = row;
             const cast = enabled ? 'Yes' : 'No';
-            const date = new Date(creationDate).toString();
+            const date = utcToZonedTime(creationDate).toLocaleString();
             return createReportSavedRow(_id, reportName, creationUserFullName, date, cast);
           });
           setControl((prev) => ({ ...prev, reportsRows: rows, reportsRowsSelected: [] }));

--- a/src/app/pages/home/Reports/Reports.js
+++ b/src/app/pages/home/Reports/Reports.js
@@ -134,9 +134,10 @@ const Reports = () => {
         .then(response => response.json())
         .then(data => {
           const rows = data.response.map((row) => {
-            const { _id, selectReport, reportName, enabled } = row;
+            const { _id, selectReport, reportName, enabled, creationUserFullName, creationDate } = row;
             const cast = enabled ? 'Yes' : 'No';
-            return createReportSavedRow(_id, reportName, 'Admin', '11/03/2020', cast);
+            const date = new Date(creationDate).toString();
+            return createReportSavedRow(_id, reportName, creationUserFullName, date, cast);
           });
           setControl((prev) => ({ ...prev, reportsRows: rows, reportsRowsSelected: [] }));
         })

--- a/src/app/pages/home/Settings/settings-tabs/Custom.jsx
+++ b/src/app/pages/home/Settings/settings-tabs/Custom.jsx
@@ -78,14 +78,16 @@ const Custom = props => {
         .then(data => {
           if (collectionName === 'settingsLists') {
             const rows = data.response.map(row => {
-              const { _id, name, options } = row;
-              return createListRow(_id, name, options.length, 'Admin', '11/03/2020');
+              const { _id, name, options, creationUserFullName, creationDate } = row;
+              const date = new Date(creationDate).toString();
+              return createListRow(_id, name, options.length, creationUserFullName, date);
             });
             setControl(prev => ({ ...prev, listRows: rows, listRowsSelected: [] }));
           } else if (collectionName === 'settingsConstants') {
             const rows = data.response.map(row => {
-              const { _id, name, value } = row;
-              return createConstantRow(_id, name, value, 'Admin', '11/03/2020');
+              const { _id, name, value, creationUserFullName, creationDate } = row;
+              const date = new Date(creationDate).toString();
+              return createConstantRow(_id, name, value, creationUserFullName, date);
             });
             setControl(prev => ({ ...prev, constantRows: rows, constantRowsSelected: [] }));
           }

--- a/src/app/pages/home/Settings/settings-tabs/Custom.jsx
+++ b/src/app/pages/home/Settings/settings-tabs/Custom.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import React, { useState, useEffect } from 'react';
+import { utcToZonedTime } from 'date-fns-tz';
 import { getDB, postDB, getOneDB, updateDB, deleteDB } from '../../../../crud/api';
 import TableComponent from '../../Components/TableComponent';
 import ModalLists from './modals/ModalLists';
@@ -79,14 +80,14 @@ const Custom = props => {
           if (collectionName === 'settingsLists') {
             const rows = data.response.map(row => {
               const { _id, name, options, creationUserFullName, creationDate } = row;
-              const date = new Date(creationDate).toString();
+              const date = utcToZonedTime(creationDate).toLocaleString();
               return createListRow(_id, name, options.length, creationUserFullName, date);
             });
             setControl(prev => ({ ...prev, listRows: rows, listRowsSelected: [] }));
           } else if (collectionName === 'settingsConstants') {
             const rows = data.response.map(row => {
               const { _id, name, value, creationUserFullName, creationDate } = row;
-              const date = new Date(creationDate).toString();
+              const date = utcToZonedTime(creationDate).toLocaleString();
               return createConstantRow(_id, name, value, creationUserFullName, date);
             });
             setControl(prev => ({ ...prev, constantRows: rows, constantRowsSelected: [] }));

--- a/src/app/pages/home/Settings/settings-tabs/LayoutsPresets.jsx
+++ b/src/app/pages/home/Settings/settings-tabs/LayoutsPresets.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import React, { useState, useEffect } from 'react';
+import { utcToZonedTime } from 'date-fns-tz';
 import { Tab, Tabs } from "@material-ui/core";
 import { getDB, postDB, getOneDB, updateDB, deleteDB } from '../../../../crud/api';
 import {
@@ -94,14 +95,14 @@ const LayoutsPresets = props => {
       .then(data => {
         if (collectionName === 'settingsLayoutsEmployees') {
           const rows = data.response.map(row => {
-            const date = new Date(row.creationDate).toString();
+            const date = utcToZonedTime(row.creationDate).toLocaleString();
             return createLayoutsEmployeeRow(row._id, row.name, 99, row.creationUserFullName, date);
           });
           setControl(prev => ({ ...prev, layoutEmployeesRows: rows, layoutEmployeesRowsSelected: [] }));
         }
         if (collectionName === 'settingsLayoutsStages') {
           const rows = data.response.map(row => {
-            const date = new Date(row.creationDate).toString();
+            const date = utcToZonedTime(row.creationDate).toLocaleString();
             return createLayoutsStageRow(row._id, row.name, row.stageName, 99, row.creationUserFullName, date);
           });
           setControl(prev => ({ ...prev, layoutStagesRows: rows, layoutStagesRowsSelected: [] }));

--- a/src/app/pages/home/Settings/settings-tabs/LayoutsPresets.jsx
+++ b/src/app/pages/home/Settings/settings-tabs/LayoutsPresets.jsx
@@ -94,13 +94,15 @@ const LayoutsPresets = props => {
       .then(data => {
         if (collectionName === 'settingsLayoutsEmployees') {
           const rows = data.response.map(row => {
-            return createLayoutsEmployeeRow(row._id, row.name, 99, 'Admin', '11/03/2020');
+            const date = new Date(row.creationDate).toString();
+            return createLayoutsEmployeeRow(row._id, row.name, 99, row.creationUserFullName, date);
           });
           setControl(prev => ({ ...prev, layoutEmployeesRows: rows, layoutEmployeesRowsSelected: [] }));
         }
         if (collectionName === 'settingsLayoutsStages') {
           const rows = data.response.map(row => {
-            return createLayoutsStageRow(row._id, row.name, row.stageName, 99, 'Admin', '11/03/2020');
+            const date = new Date(row.creationDate).toString();
+            return createLayoutsStageRow(row._id, row.name, row.stageName, 99, row.creationUserFullName, date);
           });
           setControl(prev => ({ ...prev, layoutStagesRows: rows, layoutStagesRowsSelected: [] }));
         }

--- a/src/app/pages/home/Settings/settings-tabs/Users.jsx
+++ b/src/app/pages/home/Settings/settings-tabs/Users.jsx
@@ -106,14 +106,16 @@ const Users = props => {
         if (collectionName === 'settingsAssetSpecialists') {
           const rows = data.response.map(row => {
             const { _id, categorySelected: { label: category }, userSelected: { label: user }, location: { locationName } } = row;
-            return createAssetSpecialistRow(_id, category, user, locationName, 'Admin', '11/03/2020');
+            const date = new Date(row.creationDate).toLocaleString();
+            return createAssetSpecialistRow(_id, category, user, locationName, row.creationUserFullName, date);
           });
           setControl(prev => ({ ...prev, assetSpecialistRows: rows, assetSpecialistRowsSelected: [] }));
         } else if (collectionName === 'settingsWitnesses') {
           const rows = data.response.map(row => {
             const { _id, description, userSelected: { label: user }, location: { locationName } } = row;
+            const date = new Date(row.creationDate).toLocaleString();
             // return createWitnessesRow(_id, category, user, locationName, 'Admin', '11/03/2020');
-            return createWitnessesRow(_id, description, user, locationName, 'Admin', '11/03/2020');
+            return createWitnessesRow(_id, description, user, locationName, row.creationUserFullName, date);
           });
           setControl(prev => ({ ...prev, witnessesRows: rows, witnessesRowsSelected: [] }));
         }

--- a/src/app/pages/home/Settings/settings-tabs/Users.jsx
+++ b/src/app/pages/home/Settings/settings-tabs/Users.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import React, { useEffect, useState } from 'react';
+import { utcToZonedTime } from 'date-fns-tz';
 import {
   FormControl,
   InputLabel,
@@ -106,14 +107,14 @@ const Users = props => {
         if (collectionName === 'settingsAssetSpecialists') {
           const rows = data.response.map(row => {
             const { _id, categorySelected: { label: category }, userSelected: { label: user }, location: { locationName } } = row;
-            const date = new Date(row.creationDate).toLocaleString();
+            const date = utcToZonedTime(row.creationDate).toLocaleString();
             return createAssetSpecialistRow(_id, category, user, locationName, row.creationUserFullName, date);
           });
           setControl(prev => ({ ...prev, assetSpecialistRows: rows, assetSpecialistRowsSelected: [] }));
         } else if (collectionName === 'settingsWitnesses') {
           const rows = data.response.map(row => {
             const { _id, description, userSelected: { label: user }, location: { locationName } } = row;
-            const date = new Date(row.creationDate).toLocaleString();
+            const date = utcToZonedTime(row.creationDate).toLocaleString();
             // return createWitnessesRow(_id, category, user, locationName, 'Admin', '11/03/2020');
             return createWitnessesRow(_id, description, user, locationName, row.creationUserFullName, date);
           });

--- a/src/app/pages/home/Users/Users.js
+++ b/src/app/pages/home/Users/Users.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import React, { useState, useEffect } from 'react';
+import { utcToZonedTime } from 'date-fns-tz';
 import { connect, useDispatch } from "react-redux";
 import { Tabs } from '@material-ui/core';
 import { actions } from '../../../store/ducks/general.duck';
@@ -118,14 +119,14 @@ function Users({ globalSearch, setGeneralSearch }) {
         .then(data => {
           if (collectionName === 'userProfiles') {
             const rows = data.response.map(row => {
-              const date = new Date(row.creationDate).toLocaleString();
+              const date = utcToZonedTime(row.creationDate).toLocaleString();
               return createUserProfilesRow(row._id, row.name, row.creationUserFullName, date);
             });
             setControl(prev => ({ ...prev, userProfilesRows: rows, userProfilesRowsSelected: [] }));
           }
           if (collectionName === 'user') {
             const rows = data.response.map(row => {
-              const date = new Date(row.creationDate).toLocaleString();
+              const date = utcToZonedTime(row.creationDate).toLocaleString();
               return createUserRow(row._id, row.name, row.lastName, row.email, row.designation, row.manager, row.creationUserFullName, date);
             });
             setControl(prev => ({ ...prev, usersRows: rows, usersRowsSelected: [] }));

--- a/src/app/pages/home/Users/Users.js
+++ b/src/app/pages/home/Users/Users.js
@@ -118,13 +118,15 @@ function Users({ globalSearch, setGeneralSearch }) {
         .then(data => {
           if (collectionName === 'userProfiles') {
             const rows = data.response.map(row => {
-              return createUserProfilesRow(row._id, row.name, 'Admin', '11/03/2020');
+              const date = new Date(row.creationDate).toLocaleString();
+              return createUserProfilesRow(row._id, row.name, row.creationUserFullName, date);
             });
             setControl(prev => ({ ...prev, userProfilesRows: rows, userProfilesRowsSelected: [] }));
           }
           if (collectionName === 'user') {
             const rows = data.response.map(row => {
-              return createUserRow(row._id, row.name, row.lastName, row.email, row.designation, row.manager, 'Admin', '11/03/2020');
+              const date = new Date(row.creationDate).toLocaleString();
+              return createUserRow(row._id, row.name, row.lastName, row.email, row.designation, row.manager, row.creationUserFullName, date);
             });
             setControl(prev => ({ ...prev, usersRows: rows, usersRowsSelected: [] }));
           }


### PR DESCRIPTION
## Creation information
This Pull Request contains changes on the displaying user creator and date of creation of the following module tables. Now it displays the correct information (blank if the data doesn't have it) instead of permanent text.

- Assets
- Users
- Employees
- Processes
- Locations
- Policies Table
- My Tickets
- Reports
- Settings

### Before

![image](https://user-images.githubusercontent.com/57116943/115436521-b4970e00-a1d0-11eb-8e20-e3ecc67dfdf8.png)

### After

![image](https://user-images.githubusercontent.com/57116943/115436555-bc56b280-a1d0-11eb-9cd9-6e9d44b6e944.png)