### PR TITLE
Send API Policy

### DIFF
--- a/src/_metronic/__mocks__/mockAxios.js
+++ b/src/_metronic/__mocks__/mockAxios.js
@@ -2,7 +2,7 @@ import MockAdapter from "axios-mock-adapter";
 import mockAuth from "./mockAuth";
 
 export default function mockAxios(axios) {
-  const mock = new MockAdapter(axios);
+  const mock = new MockAdapter(axios.create());
 
   mockAuth(mock);
 

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
@@ -230,6 +230,8 @@ const ModalPolicies = ({
     selectedIcon: '',
     subjectMessage: '',
     subjectNotification: '',
+    token: '',
+    tokenDisabled: true,
     urlAPI: ''
   });
 
@@ -420,8 +422,9 @@ const ModalPolicies = ({
           notificationFrom,
           notificationTo
         } = data.response;
-        const obj = pick(data.response, [
+        let obj = pick(data.response, [
           'apiDisabled',
+          'bodyAPI',
           'messageDisabled',
           'messageInternal',
           'messageMail',
@@ -434,8 +437,12 @@ const ModalPolicies = ({
           'subjectNotification',
           'selectedIcon',
           'urlAPI',
-          'bodyAPI'
+          'token',
+          'tokenDisabled'
         ]);
+        
+        obj = !obj.token && obj.tokenDisabled === undefined ? { ...obj, token: '', tokenDisabled: true } : obj;
+
         const contentBlock = htmlToDraft(layout);
         const contentState = ContentState.createFromBlockArray(
           contentBlock.contentBlocks
@@ -470,13 +477,11 @@ const ModalPolicies = ({
               filteredCustomFields = { ...filteredCustomFields, ...extractCustomFieldId(field) };
             });
           });
-          console.log("Filtered: ", filteredCustomFields);
           const filtered = { [row.name]: filteredCustomFields };
           customFieldNames = { ...customFieldNames, filtered };
           return { name: row.name, customFields: filteredCustomFields };
         })
         setCustomFields(rowToObjectsCustom.filter(({ customFields }) => Object.keys(customFields).length));
-        console.log(customFieldNames, rowToObjectsCustom.filter(({ customFields }) => Object.keys(customFields).length));
       })
       .catch(error => console.log('error>', error));
   }, [module]);
@@ -859,16 +864,17 @@ const ModalPolicies = ({
                                   id="Token-TextField"
                                   label="Web Token"
                                   margin="normal"
-                                  onChange={(e) => { }}
+                                  onChange={handleChangeName('token')}
                                   style={{ width: '90%' }}
+                                  value={values.token}
                                 />
                                 <FormControlLabel
                                   value='start'
                                   control={
                                     <Switch
-                                      checked={false}
+                                      checked={values.tokenDisabled}
                                       color="primary"
-                                      onChange={(e) => { }}
+                                      onChange={handleChangeCheck('tokenDisabled')}
                                     />
                                   }
                                   label='Disabled'

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
@@ -262,6 +262,25 @@ const ModalPolicies = ({
     setValues({ ...values, [name]: value });
   };
 
+  const handleBodyAPI = () => {
+    let jsonBodyAPI = '';
+
+    if (!values.apiDisabled) {
+      try {
+        jsonBodyAPI = JSON.parse(values.bodyAPI);
+
+        if (typeof jsonBodyAPI !== 'object') {
+          jsonBodyAPI = JSON.parse('{}');
+        }
+
+      } catch (error) {
+        jsonBodyAPI = JSON.parse('{}');
+      }
+    }
+
+    return jsonBodyAPI
+  }
+
   const handleSave = () => {
     const { selectedAction, selectedCatalogue } = values;
     if (!selectedAction || !selectedCatalogue) {
@@ -269,8 +288,11 @@ const ModalPolicies = ({
       return;
     }
     const layout = draftToHtml(convertToRaw(editor.getCurrentContent()));
+    const jsonBodyAPI = handleBodyAPI();
+
     const body = {
       ...values,
+      bodyAPI: JSON.stringify(jsonBodyAPI, null, 2),
       messageFrom,
       messageTo,
       layout,
@@ -411,7 +433,8 @@ const ModalPolicies = ({
           'subjectMessage',
           'subjectNotification',
           'selectedIcon',
-          'urlAPI'
+          'urlAPI',
+          'bodyAPI'
         ]);
         const contentBlock = htmlToDraft(layout);
         const contentState = ContentState.createFromBlockArray(
@@ -431,7 +454,7 @@ const ModalPolicies = ({
     const collection = modules.filter(({ id }) => id === module)[0];
     getDBComplex({
       collection: collection?.custom,
-      customQuery: JSON.stringify({"customFieldsTab":{"$ne":{}}})
+      customQuery: JSON.stringify({ "customFieldsTab": { "$ne": {} } })
     })
       .then(response => response.json())
       .then(data => {
@@ -804,28 +827,48 @@ const ModalPolicies = ({
                       {tab === 2 && (
                         <PortletBody>
                           <div className='__container-send-api'>
-                            <div className='__container-url-disabled'>
-                              <div className='__container-url'>
+                            <div className='__container-post'>
+                              <div className='token_textField'>
                                 <TextField
                                   className={classes.textField}
                                   id='standard-url'
                                   label='URL'
                                   margin='normal'
                                   onChange={handleChangeName('urlAPI')}
-                                  style={{ width: '600px' }}
+                                  style={{ width: '90%' }}
                                   value={values.urlAPI}
                                 />
-                              </div>
-                              <div className='__container-disabled'>
                                 <FormControlLabel
                                   value='start'
                                   control={
                                     <Switch
                                       checked={values.apiDisabled}
                                       color='primary'
-                                      onChange={handleChangeCheck(
-                                        'apiDisabled'
-                                      )}
+                                      onChange={handleChangeCheck('apiDisabled')}
+                                    />
+                                  }
+                                  label='Disabled'
+                                  labelPlacement='start'
+                                />
+                              </div>
+                            </div>
+                            <div className='__container-post'>
+                              <div className='token_textField'>
+                                <TextField
+                                  className={classes.textField}
+                                  id="Token-TextField"
+                                  label="Web Token"
+                                  margin="normal"
+                                  onChange={(e) => { }}
+                                  style={{ width: '90%' }}
+                                />
+                                <FormControlLabel
+                                  value='start'
+                                  control={
+                                    <Switch
+                                      checked={false}
+                                      color="primary"
+                                      onChange={(e) => { }}
                                     />
                                   }
                                   label='Disabled'
@@ -842,7 +885,7 @@ const ModalPolicies = ({
                                 multiline
                                 onChange={handleChangeName('bodyAPI')}
                                 rows='4'
-                                style={{ width: '100%' }}
+                                style={{ width: '90%' }}
                                 value={values.bodyAPI}
                               />
                             </div>

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
@@ -121,22 +121,22 @@ const useStyles = makeStyles((theme) => ({
     flexWrap: 'wrap'
   },
   customField: {
-    width: '40%',
     marginLeft: '15px',
+    width: '40%',
     [theme.breakpoints.down('sm')]: {
-      width: '100%',
       marginLeft: '0px',
-      marginTop: '0px'
+      marginTop: '0px',
+      width: '100%'
     }
   },
   customFieldTitle: {
     display: 'flex',
-    width: '80px',
     flexWrap: 'wrap',
     textAlign: 'justify',
+    width: '80px',
     [theme.breakpoints.down('sm')]: {
-      width: 'auto',
       marginTop: '20px',
+      width: 'auto'
     }
   },
   dense: {
@@ -465,7 +465,13 @@ const ModalPolicies = ({
           'tokenEnabled'
         ]);
 
-        // obj = !obj.token && obj.tokenDisabled === undefined ? { ...obj, token: '', tokenDisabled: true } : obj;
+        obj = !obj.apiDisabled ? { ...obj, apiDisabled: false } : obj;
+
+        obj = !obj.token ? { ...obj, token: '' } : obj;
+
+        obj = !obj.bodyAPI ? { ...obj, bodyAPI: '' } : obj;
+
+        obj = !obj.urlAPI ? { ...obj, urlAPI: '' } : obj;
 
         if (!obj.tokenEnabled && typeof obj.tokenEnabled !== 'boolean') {
           obj.tokenEnabled = false;

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
@@ -112,28 +112,50 @@ const useStyles4 = makeStyles((theme) => ({
 }));
 
 const useStyles = makeStyles((theme) => ({
+  button: {
+    display: 'block',
+    marginTop: theme.spacing(2)
+  },
   container: {
     display: 'flex',
     flexWrap: 'wrap'
+  },
+  customField: {
+    width: '40%',
+    marginLeft: '15px',
+    [theme.breakpoints.down('sm')]: {
+      width: '100%',
+      marginLeft: '0px',
+      marginTop: '0px'
+    }
+  },
+  customFieldTitle: {
+    display: 'flex',
+    width: '80px',
+    flexWrap: 'wrap',
+    textAlign: 'justify',
+    [theme.breakpoints.down('sm')]: {
+      width: 'auto',
+      marginTop: '20px',
+    }
+  },
+  dense: {
+    marginTop: 19
+  },
+  formControl: {
+    margin: theme.spacing(1),
+    minWidth: 120
+  },
+  formControlLabel: {
+    marginLeft: '10px'
+  },
+  menu: {
+    width: 200
   },
   textField: {
     marginLeft: theme.spacing(1),
     marginRight: theme.spacing(1),
     width: 200
-  },
-  dense: {
-    marginTop: 19
-  },
-  menu: {
-    width: 200
-  },
-  button: {
-    display: 'block',
-    marginTop: theme.spacing(2)
-  },
-  formControl: {
-    margin: theme.spacing(1),
-    minWidth: 120
   }
 }));
 
@@ -443,7 +465,7 @@ const ModalPolicies = ({
         ]);
 
         console.log(obj);
-        
+
         obj = !obj.token && obj.tokenDisabled === undefined ? { ...obj, token: '', tokenDisabled: true } : obj;
 
         const contentBlock = htmlToDraft(layout);
@@ -862,17 +884,11 @@ const ModalPolicies = ({
                             </div>
                             <div className='__container-post'>
                               <div className='token_textField'>
-                                <TextField
-                                  className={classes.textField}
-                                  id="Token-TextField"
-                                  label="Web Token"
-                                  margin="normal"
-                                  onChange={handleChangeName('token')}
-                                  style={{ width: '90%' }}
-                                  value={values.token}
-                                />
                                 <FormControlLabel
                                   value='start'
+                                  classes={{
+                                    labelPlacementStart: classes.formControlLabel
+                                  }}
                                   control={
                                     <Switch
                                       checked={values.tokenDisabled}
@@ -880,8 +896,17 @@ const ModalPolicies = ({
                                       onChange={handleChangeCheck('tokenDisabled')}
                                     />
                                   }
-                                  label='Disabled'
+                                  label='Web Token'
                                   labelPlacement='start'
+                                />
+                                <TextField
+                                  className={classes.textField}
+                                  id="Token-TextField"
+                                  label="Web Token"
+                                  margin="normal"
+                                  onChange={handleChangeName('token')}
+                                  style={{ width: '90%', marginLeft: '20px' }}
+                                  value={values.token}
                                 />
                               </div>
                             </div>

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
@@ -253,7 +253,7 @@ const ModalPolicies = ({
     subjectMessage: '',
     subjectNotification: '',
     token: '',
-    tokenDisabled: true,
+    tokenEnabled: false,
     urlAPI: ''
   });
 
@@ -461,12 +461,16 @@ const ModalPolicies = ({
           'selectedIcon',
           'urlAPI',
           'token',
-          'tokenDisabled'
+          'tokenDisabled',
+          'tokenEnabled'
         ]);
 
-        console.log(obj);
+        // obj = !obj.token && obj.tokenDisabled === undefined ? { ...obj, token: '', tokenDisabled: true } : obj;
 
-        obj = !obj.token && obj.tokenDisabled === undefined ? { ...obj, token: '', tokenDisabled: true } : obj;
+        if (!obj.tokenEnabled && typeof obj.tokenEnabled !== 'boolean') {
+          obj.tokenEnabled = false;
+          delete obj.tokenDisabled;
+        }
 
         const contentBlock = htmlToDraft(layout);
         const contentState = ContentState.createFromBlockArray(
@@ -891,9 +895,9 @@ const ModalPolicies = ({
                                   }}
                                   control={
                                     <Switch
-                                      checked={values.tokenDisabled}
+                                      checked={values.tokenEnabled}
                                       color="primary"
-                                      onChange={handleChangeCheck('tokenDisabled')}
+                                      onChange={handleChangeCheck('tokenEnabled')}
                                     />
                                   }
                                   label='Web Token'

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
@@ -267,17 +267,15 @@ const ModalPolicies = ({
   const handleBodyAPI = () => {
     let jsonBodyAPI = '';
 
-    if (!values.apiDisabled) {
-      try {
-        jsonBodyAPI = JSON.parse(values.bodyAPI);
+    try {
+      jsonBodyAPI = JSON.parse(values.bodyAPI);
 
-        if (typeof jsonBodyAPI !== 'object') {
-          jsonBodyAPI = JSON.parse('{}');
-        }
-
-      } catch (error) {
+      if (typeof jsonBodyAPI !== 'object') {
         jsonBodyAPI = JSON.parse('{}');
       }
+
+    } catch (error) {
+      jsonBodyAPI = JSON.parse('{}');
     }
 
     return jsonBodyAPI
@@ -302,6 +300,9 @@ const ModalPolicies = ({
       notificationTo,
       module
     };
+
+    console.log(body);
+
     if (!id) {
       postDB('policies', body)
         .then((data) => data.json())
@@ -440,6 +441,8 @@ const ModalPolicies = ({
           'token',
           'tokenDisabled'
         ]);
+
+        console.log(obj);
         
         obj = !obj.token && obj.tokenDisabled === undefined ? { ...obj, token: '', tokenDisabled: true } : obj;
 

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.scss
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.scss
@@ -117,7 +117,6 @@
     margin: 10px;
 }
 
-
 .__container-url-disabled {
     display: flex;
     justify-content: flex-start;
@@ -127,8 +126,8 @@
 .__container-url {
     align-items: center;
     display: flex;
-    width: 100%;
     padding: 0 20px;
+    width: 100%;
 }
 
 .__container-disabled {
@@ -137,8 +136,8 @@
 }
 
 .token_textField {
+	align-items: baseline;
 	display: flex;
 	flex-direction: row;
-	align-items: baseline;
     width: 90%;
 }

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.scss
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.scss
@@ -127,11 +127,17 @@
 .__container-url {
     align-items: center;
     display: flex;
-    width: 71%;
+    width: 100%;
     padding: 0 20px;
 }
 
 .__container-disabled {
     padding: 50px 0 0 0.4rem;
     width: 25%;
+}
+
+.token_textField {
+	display: flex;
+	flex-direction: row;
+	align-items: baseline;
 }

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.scss
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.scss
@@ -140,4 +140,5 @@
 	display: flex;
 	flex-direction: row;
 	align-items: baseline;
+    width: 90%;
 }

--- a/src/app/pages/home/Components/Policies/utils.js
+++ b/src/app/pages/home/Components/Policies/utils.js
@@ -9,6 +9,8 @@ export const executePolicies = (actionName, module, selectedCatalogue, policies)
     (policy) => policy.selectedAction === actionName && policy.selectedCatalogue === selectedCatalogue && policy.module === module
   );
 
+  debugger
+
   filteredPolicies.forEach(async ({
     apiDisabled,
     bodyAPI,
@@ -54,18 +56,17 @@ export const executePolicies = (actionName, module, selectedCatalogue, policies)
       simplePost(collections.notifications, notificationObj);
     }
     if (!apiDisabled) {
-
       try {
         const validBody = JSON.parse(bodyAPI);
         
         if (!tokenDisabled) {
-          debugger
-          const data = await axios.post(urlAPI, validBody, {
+          await axios.post(urlAPI, validBody, {
             headers: {
-              'Authorization': `Bearer ${token}`
+              Authorization: `Bearer ${token}`
             }
           });
-          console.log(data);
+        } else {
+          await axios.post(urlAPI, validBody);
         }
       } catch (error) {
         console.log(error);

--- a/src/app/pages/home/Components/Policies/utils.js
+++ b/src/app/pages/home/Components/Policies/utils.js
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { getCurrentDateTime, simplePost } from '../../utils';
 import { collections } from '../../constants';
 
@@ -8,7 +9,7 @@ export const executePolicies = (actionName, module, selectedCatalogue, policies)
     (policy) => policy.selectedAction === actionName && policy.selectedCatalogue === selectedCatalogue && policy.module === module
   );
 
-  filteredPolicies.forEach(({
+  filteredPolicies.forEach(async ({
     layout: html,
     messageDisabled,
     messageFrom,
@@ -19,7 +20,10 @@ export const executePolicies = (actionName, module, selectedCatalogue, policies)
     notificationTo,
     selectedIcon: icon,
     subjectMessage,
-    subjectNotification
+    subjectNotification,
+    apiDisabled,
+    urlAPI,
+    bodyAPI
   }) => {
     if (!messageDisabled) {
       const messageObj = {
@@ -46,6 +50,15 @@ export const executePolicies = (actionName, module, selectedCatalogue, policies)
         to: notificationTo
       };
       simplePost(collections.notifications, notificationObj);
+    }
+    if (!apiDisabled) {
+      try {
+        debugger
+        const data = await axios.post(urlAPI, bodyAPI);
+        console.log(data);
+      } catch (error) {
+        console.log(error);
+      }
     }
   })
 };

--- a/src/app/pages/home/Components/Policies/utils.js
+++ b/src/app/pages/home/Components/Policies/utils.js
@@ -10,6 +10,8 @@ export const executePolicies = (actionName, module, selectedCatalogue, policies)
   );
 
   filteredPolicies.forEach(async ({
+    apiDisabled,
+    bodyAPI,
     layout: html,
     messageDisabled,
     messageFrom,
@@ -21,9 +23,9 @@ export const executePolicies = (actionName, module, selectedCatalogue, policies)
     selectedIcon: icon,
     subjectMessage,
     subjectNotification,
-    apiDisabled,
     urlAPI,
-    bodyAPI
+    token,
+    tokenDisabled
   }) => {
     if (!messageDisabled) {
       const messageObj = {
@@ -52,10 +54,19 @@ export const executePolicies = (actionName, module, selectedCatalogue, policies)
       simplePost(collections.notifications, notificationObj);
     }
     if (!apiDisabled) {
+
       try {
-        debugger
-        const data = await axios.post(urlAPI, bodyAPI);
-        console.log(data);
+        const validBody = JSON.parse(bodyAPI);
+        
+        if (!tokenDisabled) {
+          debugger
+          const data = await axios.post(urlAPI, validBody, {
+            headers: {
+              'Authorization': `Bearer ${token}`
+            }
+          });
+          console.log(data);
+        }
       } catch (error) {
         console.log(error);
       }

--- a/src/app/pages/home/Components/Policies/utils.js
+++ b/src/app/pages/home/Components/Policies/utils.js
@@ -9,8 +9,6 @@ export const executePolicies = (actionName, module, selectedCatalogue, policies)
     (policy) => policy.selectedAction === actionName && policy.selectedCatalogue === selectedCatalogue && policy.module === module
   );
 
-  debugger
-
   filteredPolicies.forEach(async ({
     apiDisabled,
     bodyAPI,
@@ -58,16 +56,12 @@ export const executePolicies = (actionName, module, selectedCatalogue, policies)
     if (!apiDisabled) {
       try {
         const validBody = JSON.parse(bodyAPI);
-        
-        if (tokenEnabled) {
-          await axios.post(urlAPI, validBody, {
-            headers: {
-              Authorization: `Bearer ${token}`
-            }
-          });
-        } else {
-          await axios.post(urlAPI, validBody);
-        }
+        const headers = { Authorization: `Bearer ${token}` };
+        await axios.post(
+          urlAPI,
+          validBody,
+          { ...(tokenEnabled ? { headers } : {}) }
+        );
       } catch (error) {
         console.log(error);
       }

--- a/src/app/pages/home/Components/Policies/utils.js
+++ b/src/app/pages/home/Components/Policies/utils.js
@@ -27,7 +27,7 @@ export const executePolicies = (actionName, module, selectedCatalogue, policies)
     subjectNotification,
     urlAPI,
     token,
-    tokenDisabled
+    tokenEnabled
   }) => {
     if (!messageDisabled) {
       const messageObj = {
@@ -59,7 +59,7 @@ export const executePolicies = (actionName, module, selectedCatalogue, policies)
       try {
         const validBody = JSON.parse(bodyAPI);
         
-        if (!tokenDisabled) {
+        if (tokenEnabled) {
           await axios.post(urlAPI, validBody, {
             headers: {
               Authorization: `Bearer ${token}`

--- a/src/app/pages/home/Locations/Locations.js
+++ b/src/app/pages/home/Locations/Locations.js
@@ -41,7 +41,6 @@ import './Locations.scss';
 import ModalYesNo from '../Components/ModalYesNo';
 import Policies from '../Components/Policies/Policies';
 import { executePolicies } from '../Components/Policies/utils';
-import { usePolicies } from '../Components/Policies/hooks';
 import { hosts, getImageURL } from '../utils';
 import { allBaseFields } from '../constants';
 
@@ -59,7 +58,6 @@ const locationsTreeData = {
 const Locations = ({ globalSearch, setGeneralSearch, user }) => {
   const { showCustomAlert, showDeletedAlert, showErrorAlert } = actions;
   const theme4 = useTheme();
-  const policies = usePolicies();
   const [anchorEl, setAnchorEl] = React.useState(null);
   const [coordinates, setCoordinates] = useState([]);
   const [modalData, setModalData] = useState([])
@@ -120,13 +118,18 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
       setOpenYesNoModal(false);
     },
     removeLocation() {
-      deleteDB('locationsReal/', parentSelected)
-        .then((response) => {
-          dispatch(showDeletedAlert());
-          executePolicies('OnDelete', 'locations', 'list', policies);
-          handleLoadLocations();
+      getDB('policies')
+        .then((response) => response.json())
+        .then((data) => {
+          deleteDB('locationsReal/', parentSelected)
+            .then((_) => {
+              dispatch(showDeletedAlert());
+              executePolicies('OnDelete', 'locations', 'list', data.response);
+              handleLoadLocations();
+            })
+            .catch((_) => dispatch(showErrorAlert()));
         })
-        .catch((error) => dispatch(showErrorAlert()));
+        .catch((_) => dispatch(showErrorAlert()));
       setOpenYesNoModal(false);
     },
     openProfilesListBox(e) {
@@ -237,15 +240,20 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
 
   const onDeleteProfileLocation = (id) => {
     if (!id || !Array.isArray(id)) return;
-    id.forEach(_id => {
-      deleteDB('locations/', _id)
-        .then((response) => {
-          dispatch(showDeletedAlert());
-          executePolicies('OnDelete', 'locations', 'profiles', policies);
-          loadLocationsProfilesData();
-        })
-        .catch((error) => dispatch(showErrorAlert()));
-    });
+    getDB('policies')
+      .then((response) => response.json())
+      .then((data => {
+        id.forEach(_id => {
+          deleteDB('locations/', _id)
+            .then((_) => {
+              dispatch(showDeletedAlert());
+              executePolicies('OnDelete', 'locations', 'profiles', data.response);
+              loadLocationsProfilesData();
+            })
+            .catch((_) => dispatch(showErrorAlert()));
+        });
+      })
+        .catch((_) => dispatch(showErrorAlert())));
   };
 
   const onEditProfileLocation = (_id) => {


### PR DESCRIPTION
This PR contains changes of the  Send API Tab in the policy modal implementation.

## Token

- Now the user is able to provide a web token to the API post.
- Token can be disabled if the post does not use one.

### Before

![image](https://user-images.githubusercontent.com/57116943/117088339-d4254f00-ad17-11eb-97a5-07ece3393aec.png)

### After

![image](https://user-images.githubusercontent.com/57116943/117088355-de474d80-ad17-11eb-8cf6-737355810f4e.png)

## API Body

- Its Textfield recieves the API body.
- The body textfield have a JSON validation, if the writed body isn't a valid JSON object, it will replace it with an empty object.

![image](https://user-images.githubusercontent.com/57116943/117088391-f1f2b400-ad17-11eb-8437-3c0717145a8a.png)

![image](https://user-images.githubusercontent.com/57116943/117088414-fd45df80-ad17-11eb-800c-c0df3ee24aa1.png)