### PR TITLE
On Load Action Policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11082,9 +11082,9 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-path": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
-      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.5.tgz",
+      "integrity": "sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg=="
     },
     "object-visit": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "material-ui-color": "^0.4.6",
     "material-ui-popup-state": "^1.4.1",
     "mui-datatables": "^3.1.4",
-    "object-path": "^0.11.4",
+    "object-path": "^0.11.5",
     "perfect-scrollbar": "^1.4.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",

--- a/src/_metronic/__mocks__/mockAxios.js
+++ b/src/_metronic/__mocks__/mockAxios.js
@@ -2,7 +2,7 @@ import MockAdapter from "axios-mock-adapter";
 import mockAuth from "./mockAuth";
 
 export default function mockAxios(axios) {
-  const mock = new MockAdapter(axios);
+  const mock = new MockAdapter(axios.create());
 
   mockAuth(mock);
 

--- a/src/app/pages/home/Assets/Assets.js
+++ b/src/app/pages/home/Assets/Assets.js
@@ -529,13 +529,14 @@ function Assets({ globalSearch, user, setGeneralSearch, showDeletedAlert, showEr
                       </Grid>
                     </span>
                     <ModalAssetList
-                      key={control.idAsset}
-                      showModal={control.openAssetsModal}
-                      setShowModal={(onOff) => setControl({ ...control, openAssetsModal: onOff })}
-                      reloadTable={() => loadAssetsData('assets')}
-                      id={control.idAsset}
                       categoryRows={control.categoryRows}
+                      id={control.idAsset}
+                      key={control.idAsset}
+                      referenceRows={control.referenceRows}
                       referencesSelectedId={referencesSelectedId}
+                      reloadTable={() => loadAssetsData('assets')}
+                      setShowModal={(onOff) => setControl({ ...control, openAssetsModal: onOff })}
+                      showModal={control.openAssetsModal}
                     />
                     <div className='kt-separator kt-separator--dashed' />
                     <div className='kt-section__content'>

--- a/src/app/pages/home/Assets/Assets.js
+++ b/src/app/pages/home/Assets/Assets.js
@@ -33,6 +33,7 @@ import ModalAssetList from './modals/ModalAssetList';
 import Policies from '../Components/Policies/Policies';
 import { allBaseFields } from '../constants';
 import { executePolicies } from '../Components/Policies/utils';
+import { usePolicies } from '../Components/Policies/hooks';
 
 import './Assets.scss';
 
@@ -75,6 +76,7 @@ function Assets({ globalSearch, user, setGeneralSearch, showDeletedAlert, showEr
   const dispatch = useDispatch();
   const [tab, setTab] = useState(0);
   const [userLocations, setUserLocations] = useState([]);
+  const { policies, setPolicies } = usePolicies();
 
   const policiesBaseFields = {
     list: { ...allBaseFields.assets1, ...allBaseFields.assets2 },
@@ -532,10 +534,9 @@ function Assets({ globalSearch, user, setGeneralSearch, showDeletedAlert, showEr
                       </Grid>
                     </span>
                     <ModalAssetList
-                      categoryRows={control.categoryRows}
                       id={control.idAsset}
                       key={control.idAsset}
-                      referenceRows={control.referenceRows}
+                      policies={policies}
                       referencesSelectedId={referencesSelectedId}
                       reloadTable={() => loadAssetsData('assets')}
                       setShowModal={(onOff) => setControl({ ...control, openAssetsModal: onOff })}
@@ -611,6 +612,7 @@ function Assets({ globalSearch, user, setGeneralSearch, showDeletedAlert, showEr
                       This section will integrate <code>Assets References</code>
                     </span>
                     <ModalAssetReferences
+                      policies={policies}
                       showModal={control.openReferencesModal}
                       setShowModal={(onOff) => setControl({ ...control, openReferencesModal: onOff })}
                       reloadTable={() => loadAssetsData('references')}
@@ -677,6 +679,7 @@ function Assets({ globalSearch, user, setGeneralSearch, showDeletedAlert, showEr
                     </span>
                     <div className='kt-separator kt-separator--dashed' />
                     <ModalAssetCategories
+                      policies={policies}
                       showModal={control.openCategoriesModal}
                       setShowModal={(onOff) => setControl({ ...control, openCategoriesModal: onOff })}
                       reloadTable={() => loadAssetsData('categories')}
@@ -731,7 +734,7 @@ function Assets({ globalSearch, user, setGeneralSearch, showDeletedAlert, showEr
             </PortletBody>
           )}
 
-          {tab === 3 && <Policies module="assets" baseFields={policiesBaseFields} />}
+          {tab === 3 && <Policies setPolicies={setPolicies} module="assets" baseFields={policiesBaseFields} />}
         </Portlet>
       </div>
     </>

--- a/src/app/pages/home/Assets/Assets.js
+++ b/src/app/pages/home/Assets/Assets.js
@@ -450,6 +450,22 @@ function Assets({ globalSearch, user, setGeneralSearch, showDeletedAlert, showEr
     }
   }, [globalSearch.tabIndex, globalSearch.searchValue]);
 
+  useEffect(() => {
+    kpis.forEach(({ kpi, queryExact }) => {
+      getCountDB({ collection: 'assets', queryExact })
+        .then(response => response.json())
+        .then(data => {
+          setAssetsKPI(prev => ({
+            ...prev,
+            [kpi]: {
+              ...prev[kpi],
+              number: data.response.count
+            }
+          }));
+        });
+    });
+  }, []);
+
   return (
     <>
       <ModalYesNo

--- a/src/app/pages/home/Assets/modals/ModalAssetCategories.js
+++ b/src/app/pages/home/Assets/modals/ModalAssetCategories.js
@@ -29,7 +29,6 @@ import ImageUpload from '../../Components/ImageUpload';
 import { getFileExtension, saveImage, getImageURL } from '../../utils';
 import './ModalAssetCategories.scss';
 import { executePolicies } from '../../Components/Policies/utils';
-import { usePolicies } from '../../Components/Policies/hooks';
 
 // Example 5 - Modal
 const styles5 = theme => ({
@@ -91,14 +90,13 @@ const useStyles4 = makeStyles(theme => ({
   }
 }));
 
-const ModalAssetCategories = ({ showModal, setShowModal, reloadTable, id }) => {
+const ModalAssetCategories = ({ showModal, setShowModal, reloadTable, id, policies }) => {
   const dispatch = useDispatch();
   const { showErrorAlert, showFillFieldsAlert, showSavedAlert, showUpdatedAlert } = actions;
   // Example 4 - Tabs
   const classes4 = useStyles4();
   const theme4 = useTheme();
   const [value4, setValue4] = useState(0);
-  const policies = usePolicies();
   function handleChange4(event, newValue) {
     setValue4(newValue);
   }

--- a/src/app/pages/home/Assets/modals/ModalAssetCategories.js
+++ b/src/app/pages/home/Assets/modals/ModalAssetCategories.js
@@ -203,7 +203,6 @@ const ModalAssetCategories = ({ showModal, setShowModal, reloadTable, id }) => {
     getOneDB('categories/', id[0])
       .then(response => response.json())
       .then(data => {
-        console.log(data.response);
         const { name, depreciation, customFieldsTab, fileExt } = data.response;
         executePolicies('OnLoad', 'assets', 'categories', policies);
         const imageURL = getImageURL(id, 'categories', fileExt);

--- a/src/app/pages/home/Assets/modals/ModalAssetReferences.js
+++ b/src/app/pages/home/Assets/modals/ModalAssetReferences.js
@@ -30,7 +30,6 @@ import { getFileExtension, saveImage, getImageURL } from '../../utils';
 import { CustomFieldsPreview } from '../../constants';
 import './ModalAssetReferences.scss';
 import { executePolicies, executeOnLoadPolicy } from '../../Components/Policies/utils';
-import { usePolicies } from '../../Components/Policies/hooks';
 
 import BaseFields from '../../Components/BaseFields/BaseFields';
 
@@ -94,14 +93,13 @@ const useStyles4 = makeStyles(theme => ({
   }
 }));
 
-const ModalAssetReferences = ({ showModal, setShowModal, reloadTable, id, categoryRows }) => {
+const ModalAssetReferences = ({ showModal, setShowModal, reloadTable, id, policies }) => {
   const dispatch = useDispatch();
   const { showErrorAlert, showFillFieldsAlert, showSavedAlert, showUpdatedAlert } = actions;
   // Example 4 - Tabs
   const classes4 = useStyles4();
   const theme4 = useTheme();
   const [value4, setValue4] = useState(0);
-  const policies = usePolicies();
   function handleChange4(event, newValue) {
     setValue4(newValue);
   }
@@ -281,7 +279,6 @@ const ModalAssetReferences = ({ showModal, setShowModal, reloadTable, id, catego
       .then( async (data) => {
         const { name, brand, model, price, depreciation, customFieldsTab, fileExt, selectedProfile } = data.response;
         const { value } = selectedProfile;
-        // executePolicies('OnLoad', 'assets', 'references', policies);
         const onLoadResponse = await executeOnLoadPolicy(value, 'assets', 'references', policies);
         setCustomFieldsPathResponse(onLoadResponse);
         setValues({

--- a/src/app/pages/home/Assets/modals/ModalAssetReferences.js
+++ b/src/app/pages/home/Assets/modals/ModalAssetReferences.js
@@ -29,7 +29,7 @@ import { postDB, getOneDB, updateDB } from '../../../../crud/api';
 import { getFileExtension, saveImage, getImageURL } from '../../utils';
 import { CustomFieldsPreview } from '../../constants';
 import './ModalAssetReferences.scss';
-import { executePolicies } from '../../Components/Policies/utils';
+import { executePolicies, executeOnLoadPolicy } from '../../Components/Policies/utils';
 import { usePolicies } from '../../Components/Policies/hooks';
 
 import BaseFields from '../../Components/BaseFields/BaseFields';
@@ -274,8 +274,11 @@ const ModalAssetReferences = ({ showModal, setShowModal, reloadTable, id, catego
     getOneDB('references/', id[0])
       .then(response => response.json())
       .then(data => {
+        console.log(data.response);
         const { name, brand, model, price, depreciation, customFieldsTab, fileExt, selectedProfile } = data.response;
-        executePolicies('OnLoad', 'assets', 'references', policies);
+        const { value } = selectedProfile;
+        // executePolicies('OnLoad', 'assets', 'references', policies);
+        executeOnLoadPolicy(value, 'assets', 'references', policies);
         setValues({
           ...values,
           name,

--- a/src/app/pages/home/Assets/modals/ModalAssetReferences.js
+++ b/src/app/pages/home/Assets/modals/ModalAssetReferences.js
@@ -128,6 +128,7 @@ const ModalAssetReferences = ({ showModal, setShowModal, reloadTable, id, catego
   });
   const [customFieldsTab, setCustomFieldsTab] = useState({});
   const [tabs, setTabs] = useState([]);
+  const [customFieldsPathResponse, setCustomFieldsPathResponse] = useState();
 
   const handleChange = name => event => {
     const value = name === 'selectedProfile' ? event : event.target.value;
@@ -241,7 +242,6 @@ const ModalAssetReferences = ({ showModal, setShowModal, reloadTable, id, catego
   };
 
   const handleCloseModal = () => {
-    console.log('HANDLE CLOSE MODAL!')
     setCustomFieldsTab({});
     setValues({
       name: '',
@@ -265,7 +265,6 @@ const ModalAssetReferences = ({ showModal, setShowModal, reloadTable, id, catego
 
   useEffect(() => {
     if (!showModal) return;
-    console.log('Use Eff Ref>', id)
 
     getDB('categories/')
       .then(response => response.json())
@@ -279,12 +278,12 @@ const ModalAssetReferences = ({ showModal, setShowModal, reloadTable, id, catego
 
     getOneDB('references/', id[0])
       .then(response => response.json())
-      .then(data => {
-        console.log(data.response);
+      .then( async (data) => {
         const { name, brand, model, price, depreciation, customFieldsTab, fileExt, selectedProfile } = data.response;
         const { value } = selectedProfile;
         // executePolicies('OnLoad', 'assets', 'references', policies);
-        executeOnLoadPolicy(value, 'assets', 'references', policies);
+        const onLoadResponse = await executeOnLoadPolicy(value, 'assets', 'references', policies);
+        setCustomFieldsPathResponse(onLoadResponse);
         setValues({
           ...values,
           name,
@@ -372,6 +371,7 @@ const ModalAssetReferences = ({ showModal, setShowModal, reloadTable, id, catego
                         <div className="modal-asset-reference__list-field" >
                           {tab.content[colIndex].map(customField => (
                             <CustomFieldsPreview
+                              customFieldsPathResponse={customFieldsPathResponse}
                               id={customField.id}
                               type={customField.content}
                               values={customField.values}
@@ -381,7 +381,6 @@ const ModalAssetReferences = ({ showModal, setShowModal, reloadTable, id, catego
                               from="form"
                               tab={tab}
                               onUpdateCustomField={handleUpdateCustomFields}
-                              // customFieldIndex={props.customFieldIndex}
                               onClick={() => alert(customField.content)}
                               data={tab.content[colIndex]}
                             />

--- a/src/app/pages/home/Assets/modals/ModalAssetReferences.js
+++ b/src/app/pages/home/Assets/modals/ModalAssetReferences.js
@@ -371,18 +371,18 @@ const ModalAssetReferences = ({ showModal, setShowModal, reloadTable, id, catego
                         <div className="modal-asset-reference__list-field" >
                           {tab.content[colIndex].map(customField => (
                             <CustomFieldsPreview
+                              columnIndex={colIndex}
                               customFieldsPathResponse={customFieldsPathResponse}
+                              data={tab.content[colIndex]}
+                              from="form"
                               id={customField.id}
-                              type={customField.content}
-                              values={customField.values}
+                              onClick={() => alert(customField.content)}
                               onDelete={() => { }}
                               onSelect={() => { }}
-                              columnIndex={colIndex}
-                              from="form"
-                              tab={tab}
                               onUpdateCustomField={handleUpdateCustomFields}
-                              onClick={() => alert(customField.content)}
-                              data={tab.content[colIndex]}
+                              tab={tab}
+                              type={customField.content}
+                              values={customField.values}
                             />
                           ))}
                         </div>

--- a/src/app/pages/home/Components/CustomFields/CustomFieldsPreview/index.js
+++ b/src/app/pages/home/Components/CustomFields/CustomFieldsPreview/index.js
@@ -45,23 +45,24 @@ import './index.scss';
 
 // Custom Fields Preview
 const SingleLine = (props) => {
-  const defaultValues = {
-    fieldName: 'Single Line',
-    initialValue: '',
-  };
   const { customFieldsPathResponse } = props;
-  let onLoadField;
-  Object.entries(customFieldsPathResponse).forEach((field) => {
+  let onLoadField = '';
+  Object.entries(customFieldsPathResponse || {}).forEach((field) => {
     if (field[0] === props.id) {
       onLoadField = field[1];
     }
-  })
+  });
+  const defaultValues = {
+    fieldName: 'Single Line',
+    initialValue: onLoadField
+  };
   const [values, setValues] = useState(defaultValues);
   const handleCustomFieldClick = () => {
     props.onSelect(props.id, 'singleLine', values, setValues);
   };
   useEffect(() => {
-    if (!isEmpty(props.values)) {
+    console.log(props.id, props.values);
+    if (!isEmpty(props.values) && !onLoadField.length) {
       setValues(props.values);
     } else {
       setValues(defaultValues);
@@ -81,7 +82,7 @@ const SingleLine = (props) => {
         label={values.fieldName}
         type="text"
         margin="normal"
-        value={onLoadField || values.initialValue}
+        value={values.initialValue}
         onChange={handleOnChange}
       />
       { isPreview &&
@@ -94,16 +95,23 @@ const SingleLine = (props) => {
 };
 
 const MultiLine = (props) => {
+  const { customFieldsPathResponse } = props;
+  let onLoadField = '';
+  Object.entries(customFieldsPathResponse || {}).forEach((field) => {
+    if (field[0] === props.id) {
+      onLoadField = field[1];
+    }
+  });
   const defaultValues = {
     fieldName: 'Multi Line',
-    initialValue: ''
+    initialValue: onLoadField
   };
   const [values, setValues] = useState(defaultValues);
   const handleCustomFieldClick = () => {
     props.onSelect(props.id, 'multiLine', values, setValues);
   };
   useEffect(() => {
-    if (!isEmpty(props.values)) {
+    if (!isEmpty(props.values) && !onLoadField.length) {
       setValues(props.values);
     } else {
       setValues(defaultValues);

--- a/src/app/pages/home/Components/CustomFields/CustomFieldsPreview/index.js
+++ b/src/app/pages/home/Components/CustomFields/CustomFieldsPreview/index.js
@@ -45,6 +45,7 @@ import './index.scss';
 
 // Custom Fields Preview
 const SingleLine = (props) => {
+  console.log('Mount');
   const { customFieldsPathResponse } = props;
   let onLoadField = '';
   Object.entries(customFieldsPathResponse || {}).forEach((field) => {
@@ -53,7 +54,7 @@ const SingleLine = (props) => {
     }
   });
   const defaultValues = {
-    fieldName: 'Single Line',
+    fieldName: props.values.fieldName || 'Single Line',
     initialValue: onLoadField
   };
   const [values, setValues] = useState(defaultValues);
@@ -61,13 +62,12 @@ const SingleLine = (props) => {
     props.onSelect(props.id, 'singleLine', values, setValues);
   };
   useEffect(() => {
-    console.log(props.id, props.values);
     if (!isEmpty(props.values) && !onLoadField.length) {
       setValues(props.values);
     } else {
       setValues(defaultValues);
     }
-  }, [props.values]);
+  }, [props.values, onLoadField]);
   const [isPreview, setIsPreview] = useState(true);
   useEffect(() => setIsPreview(!props.from), [props.from]);
   const handleOnChange = e => {
@@ -103,7 +103,7 @@ const MultiLine = (props) => {
     }
   });
   const defaultValues = {
-    fieldName: 'Multi Line',
+    fieldName: props.values.fieldName || 'Multi Line',
     initialValue: onLoadField
   };
   const [values, setValues] = useState(defaultValues);
@@ -112,8 +112,10 @@ const MultiLine = (props) => {
   };
   useEffect(() => {
     if (!isEmpty(props.values) && !onLoadField.length) {
+      console.log('Pass');
       setValues(props.values);
     } else {
+      console.log('Pass 2');
       setValues(defaultValues);
     }
   }, [props.values]);

--- a/src/app/pages/home/Components/CustomFields/CustomFieldsPreview/index.js
+++ b/src/app/pages/home/Components/CustomFields/CustomFieldsPreview/index.js
@@ -49,6 +49,13 @@ const SingleLine = (props) => {
     fieldName: 'Single Line',
     initialValue: '',
   };
+  const { customFieldsPathResponse } = props;
+  let onLoadField;
+  Object.entries(customFieldsPathResponse).forEach((field) => {
+    if (field[0] === props.id) {
+      onLoadField = field[1];
+    }
+  })
   const [values, setValues] = useState(defaultValues);
   const handleCustomFieldClick = () => {
     props.onSelect(props.id, 'singleLine', values, setValues);
@@ -74,9 +81,8 @@ const SingleLine = (props) => {
         label={values.fieldName}
         type="text"
         margin="normal"
-        value={values.initialValue}
+        value={onLoadField || values.initialValue}
         onChange={handleOnChange}
-        //onChange={e => setValues({...values, initialValue: e.target.value})}
       />
       { isPreview &&
         <IconButton aria-label="Delete" size="medium" className="custom-field-preview-wrapper__delete-icon" onClick={props.onDelete}>

--- a/src/app/pages/home/Components/CustomFields/DragDropArea.js
+++ b/src/app/pages/home/Components/CustomFields/DragDropArea.js
@@ -98,7 +98,6 @@ const move = (source, destination, droppableSource, droppableDestination) => {
 };
 
 const DragDropArea = (props) => {
-  console.log('DragDropAreaProps:', props)
   const [droppables, setDroppables] = useState([]);
   const [id2List, setId2List] = useState({
     droppable: null,

--- a/src/app/pages/home/Components/Policies/Policies.jsx
+++ b/src/app/pages/home/Components/Policies/Policies.jsx
@@ -1,11 +1,11 @@
 import React from "react";
 import PoliciesTable from "./components/PoliciesTable";
 
-const Policies = ({ module, baseFields = {} }) => {
+const Policies = ({ module, setPolicies, baseFields = {} }) => {
 
   return (
     <div className="__container-policies">
-        <PoliciesTable module={module} baseFields={baseFields} />
+        <PoliciesTable setPolicies={setPolicies} module={module} baseFields={baseFields} />
     </div>
   );
 };

--- a/src/app/pages/home/Components/Policies/components/PoliciesTable.jsx
+++ b/src/app/pages/home/Components/Policies/components/PoliciesTable.jsx
@@ -3,7 +3,7 @@ import { utcToZonedTime } from 'date-fns-tz';
 import {
   PortletBody,
 } from '../../../../../partials/content/Portlet';
-import { deleteDB, getDBComplex, getCountDB } from '../../../../../crud/api';
+import { deleteDB, getDBComplex, getCountDB, getDB } from '../../../../../crud/api';
 import TableComponent2 from '../../TableComponent2';
 import ModalPolicies from '../modals/ModalPolicies';
 
@@ -44,7 +44,7 @@ const createPoliciesRow = (
   };
 };
 
-const PoliciesTable = ({ module, baseFields }) => {
+const PoliciesTable = ({ module, setPolicies, baseFields }) => {
   const [control, setControl] = useState({
     idPolicies: null,
     openPoliciesModal: false,
@@ -73,7 +73,12 @@ const PoliciesTable = ({ module, baseFields }) => {
         if (!id || !Array.isArray(id)) return;
         id.forEach((_id) => {
           deleteDB(`${collection.name}/`, _id)
-            .then((response) => loadPoliciesData(collection.name))
+            .then((response) => {
+              getDB('policies')
+                .then((response) => response.json())
+                .then((data) => setPolicies(data));
+              loadPoliciesData(collection.name);
+            })
             .catch((error) => console.log('Error', error));
         });
       },
@@ -223,6 +228,7 @@ const PoliciesTable = ({ module, baseFields }) => {
               module={module}
               baseFields={baseFields}
               reloadTable={() => loadPoliciesData('policies')}
+              setPolicies={setPolicies}
               setShowModal={(onOff) =>
                 setControl({ ...control, openPoliciesModal: onOff })
               }

--- a/src/app/pages/home/Components/Policies/components/PoliciesTable.jsx
+++ b/src/app/pages/home/Components/Policies/components/PoliciesTable.jsx
@@ -220,7 +220,6 @@ const PoliciesTable = ({ module, baseFields }) => {
             </span>
             <ModalPolicies
               id={control.idPolicies}
-              employeeProfileRows={[]}
               module={module}
               baseFields={baseFields}
               reloadTable={() => loadPoliciesData('policies')}

--- a/src/app/pages/home/Components/Policies/hooks.js
+++ b/src/app/pages/home/Components/Policies/hooks.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { getDB } from '../../../../crud/api';
 
-export const usePolicies = () => {
+export const usePolicies = (module) => {
   const [policies, setPolicies] = useState([]);
 
   useEffect(() => {
@@ -11,7 +11,7 @@ export const usePolicies = () => {
         setPolicies(data.response);
       })
       .catch((error) => console.log('error: ', error));
-  }, []);
+  }, [module]);
 
-  return policies;
+  return { policies, setPolicies };
 };

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
@@ -490,12 +490,13 @@ const ModalPolicies = ({
           'selectedIcon',
           'token',
           'tokenDisabled',
-          'tokenEnabled'
+          'tokenEnabled',
           'tokenOnLoad',
           'tokenOnLoadEnabled',
           'urlAPI',
           'urlOnLoad',
         ]);
+
         obj = !obj.apiDisabled ? { ...obj, apiDisabled: false } : obj;
 
         obj = !obj.token ? { ...obj, token: '' } : obj;
@@ -972,25 +973,26 @@ const ModalPolicies = ({
                             <div className='__container-post'>
                               <div className='token_textField'>
                                 <FormControlLabel
-                                  value='start'
                                   classes={{
                                     labelPlacementStart: classes.formControlLabel
                                   }}
                                   control={
                                     <Switch
-                                      checked={values.tokenEnabled}
-                                      color="primary"
-                                      onChange={handleChangeCheck('tokenEnabled')}
+                                    checked={values.tokenEnabled}
+                                    color="primary"
+                                    onChange={handleChangeCheck('tokenEnabled')}
                                     />
                                   }
                                   label='Web Token'
                                   labelPlacement='start'
+                                  value='start'
                                 />
                                 <TextField
                                   className={classes.textField}
                                   id="Token-TextField"
                                   label="Web Token"
                                   margin="normal"
+                                  multiline
                                   onChange={handleChangeName('token')}
                                   style={{ width: '90%', marginLeft: '20px' }}
                                   value={values.token}
@@ -1059,6 +1061,7 @@ const ModalPolicies = ({
                                 id='onLoad-tokenURL'
                                 label='Web Token'
                                 margin='normal'
+                                multiline
                                 onChange={handleChangeName('tokenOnLoad')}
                                 style={{ width: '80%', marginLeft: '20px' }}
                                 value={values.tokenOnLoad}

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
@@ -289,7 +289,14 @@ const ModalPolicies = ({
 
     if (name === 'selectedAction' && values.selectedAction === 'OnLoad' && value !== 'OnLoad') setTab(0);
 
-    if (value === 'OnLoad') setTab(3);
+    if (value === 'OnLoad') {
+      setTab(3);
+      const lastModuleCatalogue = module === 'assets' ? 'categories' : 'references';
+      if (values.selectedCatalogue === lastModuleCatalogue) {
+        setValues({ ...values, selectedCatalogue: Object.keys(baseFields)[0], [name]: value });
+        return;
+      }
+    };
 
     setValues({ ...values, [name]: value });
   };
@@ -301,7 +308,7 @@ const ModalPolicies = ({
       return;
     }
     const layout = draftToHtml(convertToRaw(editor.getCurrentContent()));
-    
+
     const body = {
       ...values,
       messageFrom,
@@ -592,11 +599,17 @@ const ModalPolicies = ({
                             value={values.selectedCatalogue}
                           >
                             {
-                              Object.keys(baseFields).map((keyName) => (
-                                <MenuItem key={keyName} value={keyName}>
-                                  {keyName.replace(/\w\S*/g, (w) => (w.replace(/^\w/, (c) => c.toUpperCase())))}
-                                </MenuItem>
-                              ))
+                              Object.keys(baseFields).map((keyName, index) => {
+                                if (values.selectedAction === 'OnLoad' && index === Object.entries(baseFields).length - 1) {
+                                  return null;
+                                }
+
+                                return (
+                                  <MenuItem key={keyName} value={keyName}>
+                                    {keyName.replace(/\w\S*/g, (w) => (w.replace(/^\w/, (c) => c.toUpperCase())))}
+                                  </MenuItem>
+                                );
+                              })
                             }
                           </Select>
                         </FormControl>

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
@@ -4,7 +4,7 @@ import { pick } from 'lodash';
 import {
   ContentState,
   convertToRaw,
-  EditorState,
+  EditorState, 
   Modifier
 } from 'draft-js';
 import { Editor } from 'react-draft-wysiwyg';
@@ -941,7 +941,7 @@ const ModalPolicies = ({
                               </Select>
                             </FormControl>
                             <div style={{ display: 'flex', flexDirection: 'column' }}>
-                              {Object.entries(values.selectedOnLoadCategory).length && (
+                              {Object.entries(values.selectedOnLoadCategory).length > 0 && (
                                 <Tabs
                                   style={{ marginLeft: '10px' }}
                                   className='builder-tabs'

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
@@ -301,10 +301,7 @@ const ModalPolicies = ({
       return;
     }
     const layout = draftToHtml(convertToRaw(editor.getCurrentContent()));
-    debugger
-
-    console.log(values);
-
+    
     const body = {
       ...values,
       messageFrom,

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
@@ -400,6 +400,7 @@ const ModalPolicies = ({
       selectedOnLoadCategory: {},
       subjectMessage: '',
       subjectNotification: '',
+      tokenEnabled: false,
       tokenOnLoad: '',
       tokenOnLoadEnabled: false,
       urlAPI: '',
@@ -469,7 +470,8 @@ const ModalPolicies = ({
           'tokenOnLoad',
           'tokenOnLoadEnabled',
           'urlAPI',
-          'urlOnLoad'
+          'urlOnLoad',
+          'tokenEnabled'
         ]);
 
         obj = !obj.onLoadDisabled ? { ...obj, onLoadDisabled: true } : obj;
@@ -477,6 +479,8 @@ const ModalPolicies = ({
         obj = !obj.urlOnLoad ? { ...obj, urlOnLoad: '' } : obj;
 
         obj = !obj.selectedOnLoadCategory ? { ...obj, selectedOnLoadCategory: {} } : obj;
+
+        obj = !obj.tokenEnabled ? { ...obj, tokenEnabled: false } : obj;
 
         obj = !obj.tokenOnLoad ? { ...obj, tokenOnLoad: '' } : obj;
 

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
@@ -160,7 +160,6 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const ModalPolicies = ({
-  employeeProfileRows,
   id,
   module,
   reloadTable,
@@ -302,16 +301,12 @@ const ModalPolicies = ({
       return;
     }
     const layout = draftToHtml(convertToRaw(editor.getCurrentContent()));
+    debugger
 
-    const validValues = values.selectedAction === 'OnLoad' ? {
-      ...values,
-      apiDisabled: true,
-      messageDisabled: true,
-      notificationDisabled: true
-    } : values;
+    console.log(values);
 
     const body = {
-      ...validValues,
+      ...values,
       messageFrom,
       messageTo,
       layout,
@@ -471,7 +466,9 @@ const ModalPolicies = ({
           'tokenEnabled'
         ]);
 
-        obj = !obj.onLoadDisabled ? { ...obj, onLoadDisabled: true } : obj;
+        console.log(obj);
+
+        obj = !obj.onLoadDisabled && typeof obj.onLoadDisabled !== 'boolean' ? { ...obj, onLoadDisabled: true } : obj;
 
         obj = !obj.onLoadFields ? { ...obj, onLoadFields: {} } : obj;
 
@@ -479,11 +476,11 @@ const ModalPolicies = ({
 
         obj = !obj.selectedOnLoadCategory ? { ...obj, selectedOnLoadCategory: {} } : obj;
 
-        obj = !obj.tokenEnabled ? { ...obj, tokenEnabled: false } : obj;
+        obj = !obj.tokenEnabled && typeof obj.tokenEnabled !== 'boolean' ? { ...obj, tokenEnabled: false } : obj;
 
         obj = !obj.tokenOnLoad ? { ...obj, tokenOnLoad: '' } : obj;
 
-        obj = !obj.tokenOnLoadEnabled ? { ...obj, tokenOnLoadEnabled: false } : obj;
+        obj = !obj.tokenOnLoadEnabled && typeof obj.tokenOnLoadEnabled !== 'boolean' ? { ...obj, tokenOnLoadEnabled: false } : obj;
 
         if (Object.entries(obj.selectedOnLoadCategory).length > 0) {
           // update custom fields
@@ -501,7 +498,6 @@ const ModalPolicies = ({
         const contentState = ContentState.createFromBlockArray(
           contentBlock.contentBlocks
         );
-        console.log(obj);
         setValues(obj);
         setMessageFrom(messageFrom);
         setMessageTo(messageTo);
@@ -510,7 +506,7 @@ const ModalPolicies = ({
         setNotificationTo(notificationTo);
       })
       .catch(error => dispatch(showErrorAlert));
-  }, [id, employeeProfileRows]);
+  }, [id]);
 
   useEffect(() => {
     const collection = modules.filter(({ id }) => id === module)[0];

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.scss
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.scss
@@ -72,6 +72,14 @@
     width: 100%;
 }
 
+.__container-on-load {
+    display: flex;
+    flex-direction: column;
+    min-height: 400px;
+    width: 100%;
+    padding: 10px 15px;
+}
+
 .__container-form-checkbox {
     display: flex;
     justify-content: space-around;
@@ -116,7 +124,6 @@
 .notification-icons {
     margin: 10px;
 }
-
 
 .__container-url-disabled {
     display: flex;

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.scss
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.scss
@@ -149,3 +149,10 @@
 	flex-direction: row;
     width: 90%;
 }
+
+.__token-on-load-container {
+    align-items: baseline;
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 25px;
+}

--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.scss
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.scss
@@ -142,3 +142,10 @@
     padding: 50px 0 0 0.4rem;
     width: 25%;
 }
+
+.__token-on-load-container {
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 25px;
+    align-items: baseline;
+}

--- a/src/app/pages/home/Components/Policies/utils.js
+++ b/src/app/pages/home/Components/Policies/utils.js
@@ -75,8 +75,6 @@ export const executeOnLoadPolicy = async (itemID, module, selectedCatalogue, pol
     (policy) => policy.selectedAction === 'OnLoad' && policy.selectedOnLoadCategory?.id === itemID && policy.selectedCatalogue === selectedCatalogue && policy.module === module
   );
 
-  debugger
-
   if (!filteredPolicies) return;
 
   const { onLoadDisabled, onLoadFields, tokenOnLoad, tokenOnLoadEnabled, urlOnLoad } = filteredPolicies;

--- a/src/app/pages/home/Components/Policies/utils.js
+++ b/src/app/pages/home/Components/Policies/utils.js
@@ -1,6 +1,7 @@
 import { getCurrentDateTime, simplePost } from '../../utils';
 import { collections } from '../../constants';
 import axios from 'axios';
+import objectPath from 'object-path';
 
 export const executePolicies = (actionName, module, selectedCatalogue, policies) => {
   const { dateFormatted, rawDate, timeFormatted } = getCurrentDateTime();
@@ -51,26 +52,39 @@ export const executePolicies = (actionName, module, selectedCatalogue, policies)
   })
 };
 
-export const executeOnLoadPolicy = (id, categoryId, module, selectedCatalogue, policies) => {
-  const filteredPolicies = policies.filter(
-    (policy) => policy.selectedAction === 'OnLoad' && policy.selectedOnLoadCategory?.id === categoryId && policy.selectedCatalogue === selectedCatalogue && policy.module === module
+export const executeOnLoadPolicy = async (itemID, module, selectedCatalogue, policies) => {
+  // debugger
+  const filteredPolicies = policies.find(
+    (policy) => policy.selectedAction === 'OnLoad' && policy.selectedOnLoadCategory?.id === itemID && policy.selectedCatalogue === selectedCatalogue && policy.module === module
   );
 
-  filteredPolicies.forEach(({
-    onLoadDisabled,
-    onLoadFields,
-    tokenOnLoad,
-    tokenOnLoadEnabled,
-    urlOnLoad
-  }) => {
-    if (!onLoadDisabled) {
-      if (tokenOnLoadEnabled) {
-        try {
+  if (!filteredPolicies) return;
 
-        } catch (error) {
-          console.log(error);
-        }
+  const { onLoadDisabled, onLoadFields, tokenOnLoad, tokenOnLoadEnabled, urlOnLoad } = filteredPolicies;
+
+  let response;
+
+  if (!onLoadDisabled) {
+    if (tokenOnLoadEnabled) {
+      try {
+        const { data } = await axios.get(urlOnLoad, {
+          headers: {
+            Authorization: `Bearer ${tokenOnLoad}`,
+          }
+        });
+        console.log(data.response);
+      } catch (error) {
+        console.log(error)
+      }
+    } else {
+      try {
+        const { data } = await axios.get(urlOnLoad);
+        console.log(data.response);
+      } catch (error) {
+        console.log(error);
       }
     }
-  });
+  }
+
+  return response;
 };

--- a/src/app/pages/home/Components/Policies/utils.js
+++ b/src/app/pages/home/Components/Policies/utils.js
@@ -1,5 +1,6 @@
 import { getCurrentDateTime, simplePost } from '../../utils';
 import { collections } from '../../constants';
+import axios from 'axios';
 
 export const executePolicies = (actionName, module, selectedCatalogue, policies) => {
   const { dateFormatted, rawDate, timeFormatted } = getCurrentDateTime();
@@ -48,4 +49,28 @@ export const executePolicies = (actionName, module, selectedCatalogue, policies)
       simplePost(collections.notifications, notificationObj);
     }
   })
+};
+
+export const executeOnLoadPolicy = (id, categoryId, module, selectedCatalogue, policies) => {
+  const filteredPolicies = policies.filter(
+    (policy) => policy.selectedAction === 'OnLoad' && policy.selectedOnLoadCategory?.id === categoryId && policy.selectedCatalogue === selectedCatalogue && policy.module === module
+  );
+
+  filteredPolicies.forEach(({
+    onLoadDisabled,
+    onLoadFields,
+    tokenOnLoad,
+    tokenOnLoadEnabled,
+    urlOnLoad
+  }) => {
+    if (!onLoadDisabled) {
+      if (tokenOnLoadEnabled) {
+        try {
+
+        } catch (error) {
+          console.log(error);
+        }
+      }
+    }
+  });
 };

--- a/src/app/pages/home/Components/Policies/utils.js
+++ b/src/app/pages/home/Components/Policies/utils.js
@@ -53,7 +53,6 @@ export const executePolicies = (actionName, module, selectedCatalogue, policies)
 };
 
 export const executeOnLoadPolicy = async (itemID, module, selectedCatalogue, policies) => {
-  // debugger
   const filteredPolicies = policies.find(
     (policy) => policy.selectedAction === 'OnLoad' && policy.selectedOnLoadCategory?.id === itemID && policy.selectedCatalogue === selectedCatalogue && policy.module === module
   );
@@ -62,29 +61,38 @@ export const executeOnLoadPolicy = async (itemID, module, selectedCatalogue, pol
 
   const { onLoadDisabled, onLoadFields, tokenOnLoad, tokenOnLoadEnabled, urlOnLoad } = filteredPolicies;
 
-  let response;
+  let res;
 
   if (!onLoadDisabled) {
     if (tokenOnLoadEnabled) {
       try {
-        const { data } = await axios.get(urlOnLoad, {
+        const { data: { response } } = await axios.get(urlOnLoad, {
           headers: {
             Authorization: `Bearer ${tokenOnLoad}`,
           }
         });
-        console.log(data.response);
+        res = handlePathResponse(response, onLoadFields);
       } catch (error) {
         console.log(error)
       }
     } else {
       try {
-        const { data } = await axios.get(urlOnLoad);
-        console.log(data.response);
+        const { data: { response } } = await axios.get(urlOnLoad);
+        res = handlePathResponse(response, onLoadFields);
       } catch (error) {
         console.log(error);
       }
     }
   }
 
-  return response;
+  return res;
+};
+
+const handlePathResponse = (response, onLoadFields, res = {}) => {
+  Object.entries(onLoadFields).forEach((customField) => {
+    const pathResponse = objectPath.get(response, customField[1]);
+    res = { ...res, [customField[0]]: pathResponse };
+  });
+
+  return res;
 };

--- a/src/app/pages/home/Components/Policies/utils.js
+++ b/src/app/pages/home/Components/Policies/utils.js
@@ -57,6 +57,8 @@ export const executeOnLoadPolicy = async (itemID, module, selectedCatalogue, pol
     (policy) => policy.selectedAction === 'OnLoad' && policy.selectedOnLoadCategory?.id === itemID && policy.selectedCatalogue === selectedCatalogue && policy.module === module
   );
 
+  debugger
+
   if (!filteredPolicies) return;
 
   const { onLoadDisabled, onLoadFields, tokenOnLoad, tokenOnLoadEnabled, urlOnLoad } = filteredPolicies;

--- a/src/app/pages/home/Components/Policies/utils.js
+++ b/src/app/pages/home/Components/Policies/utils.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import { getCurrentDateTime, simplePost } from '../../utils';
 import { collections } from '../../constants';
-import axios from 'axios';
 import objectPath from 'object-path';
 
 export const executePolicies = (actionName, module, selectedCatalogue, policies) => {

--- a/src/app/pages/home/Employees/Employees.js
+++ b/src/app/pages/home/Employees/Employees.js
@@ -17,6 +17,7 @@ import TableComponent2 from '../Components/TableComponent2';
 import { TabsTitles } from '../Components/Translations/tabsTitles';
 import ModalYesNo from '../Components/ModalYesNo';
 import Policies from '../Components/Policies/Policies';
+import { usePolicies } from '../Components/Policies/hooks';
 import ModalEmployees from './modals/ModalEmployees';
 import ModalEmployeeProfiles from './modals/ModalEmployeeProfiles';
 import { allBaseFields } from '../constants';
@@ -36,6 +37,8 @@ const Employees = ({ globalSearch, setGeneralSearch }) => {
     list: allBaseFields.employees,
     references: allBaseFields.employeeReferences
   };
+
+  const { policies, setPolicies } = usePolicies();
 
   const createUserProfilesRow = (id, name, creator, creation_date) => {
     return { id, name, creator, creation_date };
@@ -273,23 +276,6 @@ const Employees = ({ globalSearch, setGeneralSearch }) => {
     };
   };
 
-  // const executePolicies = (catalogueName) => {
-  //   const filteredPolicies = policies.filter(
-  //     ({ selectedAction }) => selectedAction === catalogueName
-  //   );
-  //   filteredPolicies.forEach(
-  //     ({ policyName, selectedAction, selectedCatalogue }) =>{
-  //       dispatch(
-  //         showCustomAlert({
-  //           open: true,
-  //           message: `Policy <${policyName}> with action <${selectedAction}> of type <${selectedCatalogue}> will be executed`,
-  //           type: 'info'
-  //         })
-  //       );
-  //     }
-  //   );
-  // };
-
   return (
     <>
       <ModalYesNo
@@ -328,6 +314,7 @@ const Employees = ({ globalSearch, setGeneralSearch }) => {
                     <ModalEmployees
                       employeeProfileRows={control.employeeProfilesRows}
                       id={control.idEmployee}
+                      policies={policies}
                       reloadTable={() => loadEmployeesData('employees')}
                       setShowModal={(onOff) =>
                         setControl({
@@ -396,6 +383,7 @@ const Employees = ({ globalSearch, setGeneralSearch }) => {
                       This section will integrate <code>User Profiles</code>
                     </span>
                     <ModalEmployeeProfiles
+                      policies={policies}
                       reloadTable={() =>
                         loadEmployeesData('employeeProfiles')
                       }
@@ -458,7 +446,7 @@ const Employees = ({ globalSearch, setGeneralSearch }) => {
             </PortletBody>
           )}
 
-          {tab === 2 && <Policies module='employees' baseFields={policiesBaseFields} />}
+          {tab === 2 && <Policies setPolicies={setPolicies} module='employees' baseFields={policiesBaseFields} />}
         </Portlet>
       </div>
     </>

--- a/src/app/pages/home/Employees/modals/ModalEmployeeProfiles.js
+++ b/src/app/pages/home/Employees/modals/ModalEmployeeProfiles.js
@@ -30,7 +30,6 @@ import CustomFields from '../../Components/CustomFields/CustomFields';
 import ImageUpload from '../../Components/ImageUpload';
 import { getFileExtension, saveImage, getImageURL } from '../../utils';
 import { executePolicies } from '../../Components/Policies/utils';
-import { usePolicies } from '../../Components/Policies/hooks';
 
 const styles5 = theme => ({
   root: {
@@ -107,13 +106,12 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-const ModalEmployeeProfiles = ({ showModal, setShowModal, reloadTable, id }) => {
+const ModalEmployeeProfiles = ({ showModal, setShowModal, reloadTable, id, policies }) => {
   const dispatch = useDispatch();
   const { showFillFieldsAlert, showErrorAlert, showSavedAlert, showUpdatedAlert } = actions;
   const classes4 = useStyles4();
   const theme4 = useTheme();
   const [value4, setValue4] = useState(0);
-  const policies = usePolicies();
 
   function handleChange4(event, newValue) {
     setValue4(newValue);

--- a/src/app/pages/home/Employees/modals/ModalEmployees.js
+++ b/src/app/pages/home/Employees/modals/ModalEmployees.js
@@ -18,7 +18,7 @@ import { withStyles, useTheme, makeStyles } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 import { useDispatch } from 'react-redux';
 import { actions } from '../../../../store/ducks/general.duck';
-import { executePolicies } from '../../Components/Policies/utils';
+import { executePolicies, executeOnLoadPolicy } from '../../Components/Policies/utils';
 import { usePolicies } from '../../Components/Policies/hooks';
 import BaseFields from '../../Components/BaseFields/BaseFields';
 import { CustomFieldsPreview } from '../../constants';
@@ -163,86 +163,7 @@ const ModalEmployees = ({
     enabled: false,
     isValidForm: {}
   });
-
-  // const executePolicies = (catalogueName) => {
-  //   const formatDate = new Date();
-  //   const { dateFormatted: currentDate, timeFormatted: currentTime } = getCurrentDateTime();
-  //   const timeStamp = `${currentDate} ${currentTime}`;
-  //   const read = false;
-  //   const status = 'new';
-  //   const filteredPolicies = policies.filter(
-  //     (policy) => policy.selectedAction === catalogueName);
-  //   filteredPolicies.forEach(({
-  //     apiDisabled,
-  //     selectedIcon,
-  //     layout,
-  //     messageDisabled,
-  //     messageFrom,
-  //     messageNotification,
-  //     messageTo,
-  //     notificationDisabled,
-  //     notificationFrom,
-  //     notificationTo,
-  //     policyName,
-  //     selectedAction,
-  //     selectedCatalogue,
-  //     subjectMessage,
-  //     subjectNotification
-  //   }) => {
-  //     if (!messageDisabled) {
-  //       return (
-  //         dispatch(
-  //           showCustomAlert({
-  //             open: true,
-  //             message: `Policy <${policyName}> with action <${selectedAction}> of type <Message> and catalogue ${selectedCatalogue} will be executed`,
-  //             type: 'info'
-  //           })
-  //         ),
-  //         postDB('messages', {
-  //           formatDate: formatDate,
-  //           from: messageFrom,
-  //           html: layout,
-  //           read: read,
-  //           status: status,
-  //           subject: subjectMessage,
-  //           timeStamp: timeStamp,
-  //           to: messageTo
-  //         })
-  //           .then(data => data.json())
-  //           .then((response) => {
-  //             const { } = response.response[0];
-  //           })
-  //           .catch((error) => console.log('ERROR', error))
-  //       )
-  //     } else if (!notificationDisabled) {
-  //       return (
-  //         dispatch(
-  //           showCustomAlert({
-  //             open: true,
-  //             message: `Policy <${policyName}> with action <${selectedAction}> of type <Notification> and catalogue ${selectedCatalogue} will be executed`,
-  //             type: 'info'
-  //           })
-  //         ),
-  //         postDB('notifications', {
-  //           formatDate: formatDate,
-  //           from: notificationFrom,
-  //           icon: selectedIcon,
-  //           message: messageNotification,
-  //           read: read,
-  //           status: status,
-  //           subject: subjectNotification,
-  //           timeStamp: timeStamp,
-  //           to: notificationTo
-  //         })
-  //           .then(data => data.json())
-  //           .then((response) => {
-  //             const { } = response.response[0];
-  //           })
-  //           .catch((error) => console.log('ERROR', error))
-  //       )
-  //     }
-  //   })
-  // };
+  const [customFieldsPathResponse, setCustomFieldsPathResponse] = useState();
 
   const handleAssignmentsOnSaving = (id) => {
     assetsToDelete.map(asset => {
@@ -482,7 +403,8 @@ const ModalEmployees = ({
 
     getOneDB('employees/', id[0])
       .then((response) => response.json())
-      .then((data) => {
+      .then( async (data) => {
+        console.log(data.response);
         const {
           name,
           lastName,
@@ -495,7 +417,8 @@ const ModalEmployees = ({
           fileExt,
           assetsAssigned = []
         } = data.response;
-        executePolicies('OnLoad', 'employees', 'list', policies);
+        const onLoadResponse = await executeOnLoadPolicy(idUserProfile, 'employees', 'list', policies);
+        setCustomFieldsPathResponse(onLoadResponse);
         setCustomFieldsTab(customFieldsTab);
         setProfilePermissions(profilePermissions);
         setLayoutSelected(layoutSelected);
@@ -628,6 +551,8 @@ const ModalEmployees = ({
                             {tab.content[colIndex].map((customField) => (
                               <CustomFieldsPreview
                                 columnIndex={colIndex}
+                                customFieldsPathResponse={customFieldsPathResponse}
+                                data={tab.content[colIndex]}
                                 from='form'
                                 id={customField.id}
                                 onClick={() => dispatch(
@@ -643,7 +568,6 @@ const ModalEmployees = ({
                                 tab={tab}
                                 type={customField.content}
                                 values={customField.values}
-                                data={tab.content[colIndex]}
                               />
                             ))}
                           </div>

--- a/src/app/pages/home/Employees/modals/ModalEmployees.js
+++ b/src/app/pages/home/Employees/modals/ModalEmployees.js
@@ -7,7 +7,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Divider,
   Typography,
   IconButton,
   Tab,
@@ -19,7 +18,6 @@ import CloseIcon from '@material-ui/icons/Close';
 import { useDispatch } from 'react-redux';
 import { actions } from '../../../../store/ducks/general.duck';
 import { executePolicies, executeOnLoadPolicy } from '../../Components/Policies/utils';
-import { usePolicies } from '../../Components/Policies/hooks';
 import BaseFields from '../../Components/BaseFields/BaseFields';
 import { CustomFieldsPreview } from '../../constants';
 import ImageUpload from '../../Components/ImageUpload'
@@ -118,6 +116,7 @@ const collections = {
 const ModalEmployees = ({
   id,
   employeeProfileRows,
+  policies,
   reloadTable,
   showModal,
   setShowModal
@@ -143,7 +142,6 @@ const ModalEmployees = ({
   const [layoutOptions, setLayoutOptions] = useState([]);
   const [layoutSelected, setLayoutSelected] = useState(0);
   const [locationsTable, setLocationsTable] = useState([]);
-  const policies = usePolicies();
   const [profilePermissions, setProfilePermissions] = useState({});
   const [profileSelected, setProfileSelected] = useState(0);
   const [tabs, setTabs] = useState([]);

--- a/src/app/pages/home/Locations/Locations.js
+++ b/src/app/pages/home/Locations/Locations.js
@@ -41,6 +41,7 @@ import './Locations.scss';
 import ModalYesNo from '../Components/ModalYesNo';
 import Policies from '../Components/Policies/Policies';
 import { executePolicies } from '../Components/Policies/utils';
+import { usePolicies } from '../Components/Policies/hooks';
 import { hosts, getImageURL } from '../utils';
 import { allBaseFields } from '../constants';
 
@@ -90,6 +91,9 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
   const [selectedLocationProfileRows, setSelectedLocationProfileRows] = useState([]);
   const [tab, setTab] = useState(0);
   const [value4, setValue4] = useState(0);
+
+  const { policies, setPolicies } = usePolicies();
+
   const { layoutConfig } = useSelector(
     ({ builder }) => ({ layoutConfig: builder.layoutConfig }),
     shallowEqual
@@ -518,6 +522,7 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
                           dataFromParent={modalData}
                           parent={parentSelected}
                           parentExt={parentFileExt}
+                          policies={policies}
                           profile={profileSelected}
                           realParent={realParentSelected}
                           reload={handleLoadLocations}
@@ -645,6 +650,7 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
                         </span>
                         <ModalLocationProfiles
                           id={id}
+                          policies={policies}
                           reloadTable={loadLocationsProfilesData}
                           setShowModal={setOpenProfileModal}
                           showModal={openProfileModal}
@@ -698,7 +704,7 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
                   </div>
                 </PortletBody>
               )}
-              {tab === 2 && <Policies module="locations" baseFields={policiesBaseFields} />}
+              {tab === 2 && <Policies setPolicies={setPolicies} module="locations" baseFields={policiesBaseFields} />}
               {tab === 3 && (
                 <PortletBody>
                   <div className='kt-section kt-margin-t-0'>

--- a/src/app/pages/home/Locations/modals/ModalLocationList.js
+++ b/src/app/pages/home/Locations/modals/ModalLocationList.js
@@ -141,6 +141,7 @@ const ModalLocationList = ({
   modalId,
   parent,
   parentExt,
+  policies,
   profile,
   realParent,
   reload,
@@ -157,7 +158,6 @@ const ModalLocationList = ({
   const [profileLabel, setProfileLabel] = useState('');
   const [tab, setTab] = useState(activeTab ? +activeTab : 0);
   const [tabs, setTabs] = useState([]);
-  const policies = usePolicies();
   const theme4 = useTheme();
   const { showCustomAlert, showErrorAlert, showSavedAlert, showUpdatedAlert } = actions;
   const [value4, setValue4] = useState(0);

--- a/src/app/pages/home/Locations/modals/ModalLocationProfiles.js
+++ b/src/app/pages/home/Locations/modals/ModalLocationProfiles.js
@@ -120,10 +120,9 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-const ModalLocationProfiles = ({ showModal, setShowModal, reloadTable, id }) => {
+const ModalLocationProfiles = ({ showModal, setShowModal, reloadTable, id, policies }) => {
   const dispatch = useDispatch();
   const { showFillFieldsAlert, showErrorAlert, showSavedAlert, showUpdatedAlert } = actions;
-  const policies = usePolicies();
   // Example 4 - Tabs
   const classes4 = useStyles4();
   const theme4 = useTheme();

--- a/src/app/pages/home/Users/Users.js
+++ b/src/app/pages/home/Users/Users.js
@@ -15,6 +15,7 @@ import * as general from "../../../store/ducks/general.duck";
 import TableComponent2 from '../Components/TableComponent2';
 import { TabsTitles } from '../Components/Translations/tabsTitles';
 import { executePolicies } from '../Components/Policies/utils';
+import { usePolicies } from '../Components/Policies/hooks';
 import ModalUserProfiles from './modals/ModalUserProfiles';
 import ModalUsers from './modals/ModalUsers';
 
@@ -28,6 +29,8 @@ function Users({ globalSearch, setGeneralSearch }) {
   const dispatch = useDispatch();
   const { showDeletedAlert, showErrorAlert } = actions;
   const [tab, setTab] = useState(0);
+
+  const { policies, setPolicies } = usePolicies();
 
   const policiesBaseFields = {
     list: allBaseFields.userList,
@@ -271,6 +274,7 @@ function Users({ globalSearch, setGeneralSearch }) {
                       This section will integrate <code>Users List</code>
                     </span>
                     <ModalUsers
+                      policies={policies}
                       showModal={control.openUsersModal}
                       setShowModal={(onOff) => setControl({ ...control, openUsersModal: onOff })}
                       reloadTable={() => loadUsersData('user')}
@@ -282,15 +286,6 @@ function Users({ globalSearch, setGeneralSearch }) {
                       <TableComponent2
                         controlValues={tableControl.user}
                         headRows={usersHeadRows}
-                        // locationControl={(locations) => {
-                        //   setTableControl(prev => ({
-                        //     ...prev,
-                        //     users: {
-                        //       ...prev.users,
-                        //       locationsFilter: locations
-                        //     }
-                        //   }))
-                        // }}
                         onAdd={tableActions('users').onAdd}
                         onDelete={tableActions('users').onDelete}
                         onEdit={tableActions('users').onEdit}
@@ -345,6 +340,7 @@ function Users({ globalSearch, setGeneralSearch }) {
                       This section will integrate <code>User Profiles</code>
                     </span>
                     <ModalUserProfiles
+                      policies={policies}
                       showModal={control.openUserProfilesModal}
                       setShowModal={(onOff) => setControl({ ...control, openUserProfilesModal: onOff })}
                       reloadTable={() => loadUsersData('userProfiles')}
@@ -400,7 +396,7 @@ function Users({ globalSearch, setGeneralSearch }) {
             </PortletBody>
           )}
 
-          {tab === 2 && <Policies module="user" baseFields={policiesBaseFields} />}
+          {tab === 2 && <Policies setPolicies={setPolicies} module="user" baseFields={policiesBaseFields} />}
         </Portlet>
       </div>
     </>

--- a/src/app/pages/home/Users/modals/ModalUserProfiles.js
+++ b/src/app/pages/home/Users/modals/ModalUserProfiles.js
@@ -90,14 +90,13 @@ const useStyles4 = makeStyles(theme => ({
   }
 }));
 
-const ModalUserProfiles = ({ showModal, setShowModal, reloadTable, id }) => {
+const ModalUserProfiles = ({ showModal, setShowModal, reloadTable, id, policies }) => {
   const dispatch = useDispatch();
   const { showErrorAlert, showFillFieldsAlert, showSavedAlert, showUpdatedAlert } = actions;
   // Example 4 - Tabs
   const classes4 = useStyles4();
   const theme4 = useTheme();
   const [value4, setValue4] = useState(0);
-  const policies = usePolicies();
   function handleChange4(event, newValue) {
     setValue4(newValue);
   }

--- a/src/app/pages/home/Users/modals/ModalUsers.js
+++ b/src/app/pages/home/Users/modals/ModalUsers.js
@@ -112,9 +112,8 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-const ModalUsers = ({ showModal, setShowModal, reloadTable, id, userProfileRows, user, updateUserPic }) => {
+const ModalUsers = ({ showModal, setShowModal, reloadTable, id, userProfileRows, user, updateUserPic, policies }) => {
   const dispatch = useDispatch();
-  const policies = usePolicies();
   const { showErrorAlert, showFillFieldsAlert, showSavedAlert, showUpdatedAlert } = actions;
   const classes4 = useStyles4();
   const theme4 = useTheme();


### PR DESCRIPTION
## General
This PR contains changes related to the on load action in `policies` module.

- A new tab pops up and the other ones do not display if the selected action in the policies modal is a `on load` action.
- The catalogues selection is reduced if the selected action is a `on load` action.
- A warning pops up if the selected action is `on load`  and another existing `on load`  policy targets the selected catalogue.

### Before

![image](https://user-images.githubusercontent.com/57116943/118073645-e172b700-b371-11eb-8144-ea4965f7fffe.png)
![image](https://user-images.githubusercontent.com/57116943/118073764-1d0d8100-b372-11eb-8b1e-4b1f2015c133.png)

### After

![image](https://user-images.githubusercontent.com/57116943/118073667-ef283c80-b371-11eb-8d59-e0c9cc7a547f.png)
![image](https://user-images.githubusercontent.com/57116943/118073789-28f94300-b372-11eb-9390-62300c0dfd05.png)
![image](https://user-images.githubusercontent.com/57116943/118073722-06672a00-b372-11eb-81b4-2f51c3ba09b9.png)

## On Load Tab
This tab contains the on load form. It only appears if the selected action is a `on load` action. These are the following values that can be find in the form:

- API URL.
- On load switch to define if the action is disbaled or not.
- Web token switch to define if the a token will be used or not.
- The web token field.
- A selector to determine the module category that the action will use. if a category is selected it's custom tabs and custom fields will pop up below the selector.
- The custom field value must be the object path of the url provided response.

![image](https://user-images.githubusercontent.com/57116943/118073858-5b0aa500-b372-11eb-8790-b80ad46ee08d.png)
![image](https://user-images.githubusercontent.com/57116943/118074252-2c40fe80-b373-11eb-91e4-1d383cf1131e.png)
![image](https://user-images.githubusercontent.com/57116943/118074272-3531d000-b373-11eb-8fd3-e4d2e6aa21ab.png)

## URL Response
![image](https://user-images.githubusercontent.com/57116943/118074520-aec9be00-b373-11eb-8787-62fb12c9f384.png)
