### PR TITLE
Second iteration on process, Reports conected and several changes were made

### DIFF
--- a/src/app/crud/api.js
+++ b/src/app/crud/api.js
@@ -133,11 +133,13 @@ const getDBComplex = ({
       res[key] = isValueBool ? value : { "$regex": `(?i).*${value}.*` };
       return res;
     });
-    const queryString = JSON.stringify({ "$and": [{ "$or": qLike }, condition] });
+    const text = condition.map((e) => JSON.stringify(e)).join(",");
+    const queryString = JSON.stringify({ "$and": [{ "$or": qLike }, text] }).replace(/\\+/g, "").replace(/"{/g, "{").replace(/}"/g, "}");
     additionalParams += `query=${queryString}`;
     count++;
   } else if (!queryLike && condition) {
-    const queryString = JSON.stringify({ "$and": [condition] });
+    const text = condition.map((e) => JSON.stringify(e)).join(",");
+    const queryString = JSON.stringify({ "$and": [text] }).replace(/\\+/g, "").replace(/"{/g, "{").replace(/}"/g, "}");
     additionalParams += `query=${queryString}`;
     count++;
   }
@@ -191,10 +193,12 @@ const getCountDB = ({
       res[key] = isValueBool ? value : { "$regex": `(?i).*${value}.*` };
       return res;
     });
-    const queryString = JSON.stringify({ "$and": [{ "$or": qLike }, condition] });
+    const text = condition.map((e) => JSON.stringify(e)).join(",");
+    const queryString = JSON.stringify({ "$and": [{ "$or": qLike }, text] }).replace(/\\+/g, "").replace(/"{/g, "{").replace(/}"/g, "}");
     additionalParams += `query=${queryString}`;
   } else if (!queryLike && condition) {
-    const queryString = JSON.stringify({ "$and": [condition] });
+    const text = condition.map((e) => JSON.stringify(e)).join(",");
+    const queryString = JSON.stringify({ "$and": [text] }).replace(/\\+/g, "").replace(/"{/g, "{").replace(/}"/g, "}");
     additionalParams += `query=${queryString}`;
   }
   if (queryExact) {

--- a/src/app/pages/home/Assets/Assets.js
+++ b/src/app/pages/home/Assets/Assets.js
@@ -250,7 +250,7 @@ function Assets({ globalSearch, user, setGeneralSearch, showDeletedAlert, showEr
       getCountDB({
         collection: collectionName,
         queryLike: tableControl[collectionName].search || tableControl['assets'].locationsFilter.length ? queryLike : null,
-        condition: collectionName === 'assets' ? { "location": { "$in": userLocations } } : null
+        condition: collectionName === 'assets' ? [{ "location": { "$in": userLocations }}] : null
       })
         .then(response => response.json())
         .then(data => {
@@ -269,7 +269,7 @@ function Assets({ globalSearch, user, setGeneralSearch, showDeletedAlert, showEr
         skip: tableControl[collectionName].rowsPerPage * tableControl[collectionName].page,
         sort: [{ key: tableControl[collectionName].orderBy, value: tableControl[collectionName].order }],
         queryLike: tableControl[collectionName].search || tableControl['assets'].locationsFilter.length ? queryLike : null,
-        condition: collectionName === 'assets' ? { "location": { "$in": userLocations } } : null
+        condition: collectionName === 'assets' ? [{ "location": { "$in": userLocations } }] : null
       })
         .then(response => response.json())
         .then(data => {

--- a/src/app/pages/home/Assets/modals/ModalAssetList.js
+++ b/src/app/pages/home/Assets/modals/ModalAssetList.js
@@ -174,12 +174,16 @@ const ModalAssetList = ({ showModal, setShowModal, referencesSelectedId, reloadT
     assetsToDelete.map(asset => {
       updateDB('assets/', { parent: null }, asset.id)
         .then((response) => { })
-        .catch(error => dispatch(showErrorAlert()));
+        .catch(error => {
+          dispatch(showErrorAlert())
+        });
     });
     assetsBeforeSaving.map(asset => {
       updateDB('assets/', { parent: id[0] }, asset.id)
         .then(response => { })
-        .catch(error => dispatch(showErrorAlert()));
+        .catch(error => {
+          dispatch(showErrorAlert())
+        });
     });
   };
 
@@ -447,22 +451,19 @@ const ModalAssetList = ({ showModal, setShowModal, referencesSelectedId, reloadT
 
   const handleLoadCustomFields = (profile) => {
     if (!profile || !profile.id) return;
-    console.log('id:', id)
     getOneDB('categories/', profile.id)
       .then(response => response.json())
       .then(data => {
-        console.log(data.response);
         const { customFieldsTab, depreciation } = data.response;
-        console.log('customFieldsTab:', customFieldsTab)
         const tabs = Object.keys(customFieldsTab).map(key => ({ key, info: customFieldsTab[key].info, content: [customFieldsTab[key].left, customFieldsTab[key].right] }));
         tabs.sort((a, b) => a.key.split('-').pop() - b.key.split('-').pop());
-
-        console.log('tabs:', tabs)
         setCustomFieldsTab(customFieldsTab);
         setValues(prev => ({ ...prev, depreciation }));
         setTabs(tabs);
       })
-      .catch(error => dispatch(showErrorAlert()));
+      .catch(error => {
+        dispatch(showErrorAlert())
+      });
   };
 
   const handleSave = () => {
@@ -482,8 +483,6 @@ const ModalAssetList = ({ showModal, setShowModal, referencesSelectedId, reloadT
       mapCoords: mapMarker ? mapMarker : null,
       children: assetsBeforeSaving,
     };
-    console.log('body:', body)
-    // console.log('isNew:', isNew)
     if (!id) {
       body.referenceId = referencesSelectedId;
       postDB('assets', body)
@@ -494,7 +493,9 @@ const ModalAssetList = ({ showModal, setShowModal, referencesSelectedId, reloadT
           saveAndReload('assets', _id);
           executePolicies('OnAdd', 'assets', 'list', policies);
         })
-        .catch(error => dispatch(showErrorAlert()));
+        .catch(error => {
+          dispatch(showErrorAlert())
+        });
     } else {
       updateDB('assets/', body, id[0])
         .then(response => {
@@ -502,7 +503,9 @@ const ModalAssetList = ({ showModal, setShowModal, referencesSelectedId, reloadT
           saveAndReload('assets', id[0]);
           executePolicies('OnEdit', 'assets', 'list', policies);
         })
-        .catch(error => dispatch(showErrorAlert()));
+        .catch(error => {
+          dispatch(showErrorAlert())
+        });
     }
     handleCloseModal();
   };
@@ -563,7 +566,6 @@ const ModalAssetList = ({ showModal, setShowModal, referencesSelectedId, reloadT
 
   useEffect(() => {
     if (!showModal) return;
-    console.log('referencesSelectedId:', referencesSelectedId)
 
     if (referencesSelectedId) {
       getOneDB('references/', referencesSelectedId)
@@ -581,18 +583,17 @@ const ModalAssetList = ({ showModal, setShowModal, referencesSelectedId, reloadT
           setCustomFieldsTab(customFieldsTab);
           setTabs(tabs);
         })
-        .catch(error => dispatch(showErrorAlert()));
+        .catch(error => {
+          dispatch(showErrorAlert())
+        });
     }
 
-    // const profiles = categoryRows.map(cat => ({ id: cat.id, name: cat.name }));
-    // console.log('profiles:', profiles)
-    // setValues(prev => ({ ...prev, profiles }));
     if (!id || !Array.isArray(id)) return;
 
     getOneDB('assets/', id[0])
       .then(response => response.json())
       .then(data => {
-        const { name, brand, model, category, status, serial, responsible, notes, quantity, purchase_date, purchase_price, price, total_price, EPC, location, creator, creation_date, labeling_user, labeling_date, customFieldsTab, fileExt, assigned, layoutCoords, mapCoords, children } = data.response;
+        const { name, brand, model, category, status, serial, responsible, notes, quantity, purchase_date, purchase_price, price, total_price, EPC, location, creator, creation_date, labeling_user, labeling_date, customFieldsTab, fileExt, assigned, layoutCoords, mapCoords, children, history } = data.response;
         executePolicies('OnLoad', 'assets', 'list', policies);
         setAssetLocation(location);
         setLayoutMarker(layoutCoords) //* null if not specified
@@ -625,11 +626,14 @@ const ModalAssetList = ({ showModal, setShowModal, referencesSelectedId, reloadT
                 creation_date,
                 labeling_user,
                 labeling_date,
+                history,
                 imageURL: getImageURL(id, 'assets', fileExt),
                 assignedTo: `${nameRes ? nameRes : ''} ${lastName ? lastName : ''}`,
               });
             })
-            .catch(error => dispatch(showErrorAlert()));
+            .catch(error => {
+              dispatch(showErrorAlert())
+            });
         }
         else {
           setValues({
@@ -653,15 +657,20 @@ const ModalAssetList = ({ showModal, setShowModal, referencesSelectedId, reloadT
             creation_date,
             labeling_user,
             labeling_date,
+            history,
             imageURL: getImageURL(id, 'assets', fileExt),
           });
         }
-        const tabs = Object.keys(customFieldsTab).map(key => ({ key, info: customFieldsTab[key].info, content: [customFieldsTab[key].left, customFieldsTab[key].right] }));
+        if(customFieldsTab){
+          const tabs = Object.keys(customFieldsTab).map(key => ({ key, info: customFieldsTab[key].info, content: [customFieldsTab[key].left, customFieldsTab[key].right] }));
         tabs.sort((a, b) => a.key.split('-').pop() - b.key.split('-').pop());
         setCustomFieldsTab(customFieldsTab);
         setTabs(tabs);
+        }
       })
-      .catch(error => dispatch(showErrorAlert()));
+      .catch(error => {
+        dispatch(showErrorAlert())
+      });
   }, [showModal]);
 
 
@@ -684,56 +693,35 @@ const ModalAssetList = ({ showModal, setShowModal, referencesSelectedId, reloadT
     <div style={{ width: '1000px' }}>
       <Dialog onClose={() => setOpenHistory(false)} aria-labelledby="simple-dialog-title" open={openHistory}>
         <DialogTitle id="simple-dialog-title">History</DialogTitle>
-        <Timeline >
-          <TimelineItem>
-            <TimelineOppositeContent>
-              <Typography color="textSecondary">03/08/2017</Typography>
-            </TimelineOppositeContent>
-            <TimelineSeparator>
-              <TimelineDot />
-              <TimelineConnector />
-            </TimelineSeparator>
-            <TimelineContent>
-              <Typography>Down for maintenance</Typography>
-            </TimelineContent>
-          </TimelineItem>
-          <TimelineItem>
-            <TimelineOppositeContent>
-              <Typography color="textSecondary">21/03/2018</Typography>
-            </TimelineOppositeContent>
-            <TimelineSeparator>
-              <TimelineDot />
-              <TimelineConnector />
-            </TimelineSeparator>
-            <TimelineContent>
-              <Typography>Asigned to a new user</Typography>
-            </TimelineContent>
-          </TimelineItem>
-          <TimelineItem>
-            <TimelineOppositeContent>
-              <Typography color="textSecondary">12/12/2019</Typography>
-            </TimelineOppositeContent>
-            <TimelineSeparator>
-              <TimelineDot />
-              <TimelineConnector />
-            </TimelineSeparator>
-            <TimelineContent>
-              <Typography>Location was changed</Typography>
-            </TimelineContent>
-          </TimelineItem>
-          <TimelineItem>
-            <TimelineOppositeContent>
-              <Typography color="textSecondary">26/02/2020</Typography>
-            </TimelineOppositeContent>
-            <TimelineSeparator>
-              <TimelineDot />
-              <TimelineConnector />
-            </TimelineSeparator>
-            <TimelineContent>
-              <Typography>Asset was Deleted</Typography>
-            </TimelineContent>
-          </TimelineItem>
+        {
+          !values || !values.history && (
+            <div style={{padding: '10px', margin: '10px'}}>
+              <Typography>This Asset has no History</Typography>
+            </div>
+          )
+        }
+        {
+          <Timeline >
+          {
+            values?.history?.map(({processName,processType, date, label}) => (
+              <TimelineItem>
+                <TimelineOppositeContent>
+                  <Typography>{processName}</Typography>
+                  <Typography color="textSecondary">{processType}</Typography>
+                  <Typography color="textSecondary">{date}</Typography>
+                </TimelineOppositeContent>
+                <TimelineSeparator>
+                  <TimelineDot />
+                  <TimelineConnector />
+                </TimelineSeparator>
+                <TimelineContent>
+                  <Typography>{label}</Typography>
+                </TimelineContent>
+              </TimelineItem>
+            ))
+          }
         </Timeline>
+        }
       </Dialog>
       <Dialog
         onClose={handleCloseModal}

--- a/src/app/pages/home/Components/Policies/components/PoliciesTable.jsx
+++ b/src/app/pages/home/Components/Policies/components/PoliciesTable.jsx
@@ -139,7 +139,7 @@ const PoliciesTable = ({ module, baseFields }) => {
       getCountDB({
         collection: collectionName,
         queryLike: tableControl[collectionName].search ? queryLike : null,
-        condition: { "module": { "$eq": module } }
+        condition: [{ "module": { "$eq": module } }]
       })
         .then(response => response.json())
         .then(data => {
@@ -158,7 +158,7 @@ const PoliciesTable = ({ module, baseFields }) => {
         skip: tableControl[collectionName].rowsPerPage * tableControl[collectionName].page,
         sort: [{ key: tableControl[collectionName].orderBy, value: tableControl[collectionName].order }],
         queryLike: tableControl[collectionName].search ? queryLike : null,
-        condition: { "module": { "$eq": module } }
+        condition: [{ "module": { "$eq": module } }]
       })
         .then(response => response.json())
         .then(data => {

--- a/src/app/pages/home/Processes/components/LiveProcessTab.jsx
+++ b/src/app/pages/home/Processes/components/LiveProcessTab.jsx
@@ -15,17 +15,25 @@ import LiveProcessInfo from './LiveProcessInfo';
 const LiveProcessTab = ({
   onSelectionChange,
   processInfo,
+  processType,
   setCartRows,
-  onSetRows
+  onSetRows,
+  user
 }) => {
   const [tabIndex, setTabIndex] = useState(0);
   const [openModal, setOpenModal] = useState(false);
   const [selection, setSelection] = useState([]);
   const [localCartRows, setLocalCartRows] = useState([]);
+  const [currentStage, setCurrentStage] = useState([]);
   
   useEffect(() => {
-    setLocalCartRows(processInfo.cartRows);
-  }, [processInfo.cartRows])
+    if(Object.keys(processInfo).length){
+      setLocalCartRows(processInfo.cartRows);
+      const stageKeys = Object.keys(processInfo.processData.stages);
+      const _currentStage = processInfo.processData.stages[stageKeys[processInfo.processData.currentStage-1]];
+      setCurrentStage(_currentStage);
+    }
+  }, [processInfo]);
 
   const handleRejectionClick = () => {
     if (selection.length) {
@@ -51,6 +59,18 @@ const LiveProcessTab = ({
   };
   const handleSelection = ({ rows }) => {
     setSelection(rows);
+  };
+  const showButtons = () => {
+   if(!Object.keys(currentStage).length > 0){
+     return false;
+   };
+
+   const stageApprovals = currentStage.approvals.map(({_id}) => _id);
+   if(!stageApprovals.includes(user.id) || currentStage.stageFulfilled){
+     return false;
+   }
+   
+    return true;
   };
 
   return (
@@ -82,25 +102,29 @@ const LiveProcessTab = ({
           />
         </TabContainer>
         <TabContainer>
-          <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '10px', marginBottom: '25px' }}>
-            <Button
-              color="secondary"
-              endIcon={<Icon>thumb_down</Icon>}
-              onClick={handleRejectionClick}
-              variant="contained"
-            >
-              Reject
-            </Button>
-            <Button
-              color="secondary"
-              endIcon={<Icon>thumb_up</Icon>}
-              style={{ backgroundColor: 'green', marginLeft: '20px' }}
-              onClick={handleApproveOkClick}
-              variant="contained"
-            >
-              Approve
-            </Button>
-          </div>
+          {
+            showButtons() && (
+              <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '10px', marginBottom: '25px' }}>
+                <Button
+                  color="secondary"
+                  endIcon={<Icon>thumb_down</Icon>}
+                  onClick={handleRejectionClick}
+                  variant="contained"
+                >
+                  Reject
+                </Button>
+                <Button
+                  color="secondary"
+                  endIcon={<Icon>thumb_up</Icon>}
+                  style={{ backgroundColor: 'green', marginLeft: '20px' }}
+                  onClick={handleApproveOkClick}
+                  variant="contained"
+                >
+                  Approve
+                </Button>
+              </div>
+            )
+          }
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             <AssetFinderPreview
               isAssetReference={true}
@@ -110,6 +134,7 @@ const LiveProcessTab = ({
               onSelectionChange={handleSelection}
               rows={localCartRows}
               onSetRows={setCartRows}
+              processType={processType}
             />
           </div>
         </TabContainer>

--- a/src/app/pages/home/Processes/components/LiveProcesses.jsx
+++ b/src/app/pages/home/Processes/components/LiveProcesses.jsx
@@ -197,7 +197,9 @@ const LiveProcesses = ({ user }) => {
         <ModalProcessesLive
           showModal={control.openProcessLiveModal}
           setShowModal={(onOff) => setControl({ ...control, openProcessLiveModal: onOff })}
-          reloadTable={() => loadLayoutsData('processLive')}
+          reloadTable={() => {
+            loadLayoutsData()
+          }}
           // reloadTable={() => loadLayoutsData()}
           id={control.idProcessLive}
           // employeeProfileRows={[]}

--- a/src/app/pages/home/Reports/reportsHelpers.js
+++ b/src/app/pages/home/Reports/reportsHelpers.js
@@ -16,7 +16,8 @@ const _generalFields = {
   categories: ['_id', 'name', 'depreciation'],
   references: ['_id', 'name', 'brand', 'model', 'price'],
   assets: ['_id', 'name', 'brand', 'model', 'category', 'status', 'serial', 'responsible', 'notes', 'quantity', 'purchase_date', 'purchase_price', 'price', 'total_price', 'EPC', 'location', 'creator', 'creation_date', 'labeling_user', 'labeling_date'],
-  depreciation: []
+  depreciation: [],
+  processLive: ['folio', 'name', 'stages', 'type', 'creator', 'date']
 };
 
 export const formatCollection = (collectionName, completeFields) => {

--- a/src/app/pages/home/utils.js
+++ b/src/app/pages/home/utils.js
@@ -84,3 +84,31 @@ export const simplePost = (collection, object) => {
   postDB(collection, object)
     .catch((error) => console.error('ERROR', error))
 };
+
+export const getLocationPath = async (locationId) => {
+  const allLocations = await getAllLocations();
+  const firstLocation = allLocations.find(({ id }) => id === locationId);
+  const response = recursiveLocationPath(firstLocation, allLocations);
+  return response;
+};
+
+const getAllLocations = async () => {
+  return await getDB('locationsReal/')
+    .then(response => response.json())
+    .then(data => {
+      const filtered = data.response.map(({ _id: id, name, parent }) => ({ id, name, parent }))
+      return filtered;
+    })
+    .catch(error => console.log(error));
+}
+
+const recursiveLocationPath = (currentLocation, allLocations) => {
+  const { name, parent } = currentLocation;
+  if (parent === 'root') {
+    return name;
+  }
+  else {
+    const newLocation = allLocations.find(({ id }) => id === parent);
+    return recursiveLocationPath(newLocation, allLocations).concat('/', name);
+  }
+};

--- a/src/app/partials/layout/MessagesTopBar.js
+++ b/src/app/partials/layout/MessagesTopBar.js
@@ -145,7 +145,7 @@ const MessagesTopBar = ({
 
     getDBComplex({
       collection: 'messages',
-      condition: { "to": { "$elemMatch": { "_id": user.id } } }
+      condition: [{ "to": { "$elemMatch": { "_id": user.id } } }]
     })
       .then(response => response.json())
       .then(data => {


### PR DESCRIPTION

- Added the `Folio` prop to each process, to be self-increasing and consecutive
- When listing real assets, it shows assets that are not inProcess nor decommissioned nor maintenance 
- The Asset Status is updated properly according to each process stage.
- In the search of real or reference assets, the user needs to insert a query to get an answer.
- When assigning a location the user can only assign those locations that are AssetRepositories.
- All tables in `processLive` are properly updated.
- Reject and approve buttons are shown only when the user who opens the modal is an `ApprovalUser`.
- Created the `Location Path` algorithm .
- Added location path to some of the information displayed on `AssetsPreviewFinder`.
- Some information Columns are shown dynamically on `ModalProcessLive` according to the type of process selected.
- Added the `history` functionality to update the assets' history on each process.
- Added a new ProcessStatus field to the ProcessLive document to know the overall status of the process.
- Assets status will be edited on a process even when some of them are Rejected
- Connected with Timeline
- Connected with Reports and added all the necessary filters.

**Bugs Fixed:**
- When creating a new process and changing the selected Type of process, all the vales reset to default to prevent any fatal error.
- When a process is Rejected, the Status of the assets stays with "in-process" instead of returning to active, so even when 
rejected, the asset can't be used on another process