### PR TITLE
Policies corrections

### DIFF
--- a/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
+++ b/src/app/pages/home/Components/Policies/modals/ModalPolicies.js
@@ -397,22 +397,19 @@ const ModalPolicies = ({
       );
       setEditor(EditorState.push(editor, contentState, 'insert-characters'));
     } else {
-      const text = values[selectedControl];
-
-      if (!text) {
+      try {
+        const text = values[selectedControl];
+        const left = text.substr(0, cursorPosition[0]);
+        const right = text.substr(cursorPosition[1], text.length);
+        const final = `${left}%{${varId}}${right}`;
+        setValues({ ...values, [selectedControl]: final });
+      } catch (error) {
         dispatch(showCustomAlert({
-          type: 'warning',
-          message: 'Please focus the message body to insert a field',
-          open: true
+          message: 'Please select a field or message body to place variables',
+          open: true,
+          type: 'warning'
         }));
-
-        return;
       }
-
-      const left = text.substr(0, cursorPosition[0]);
-      const right = text.substr(cursorPosition[1], text.length);
-      const final = `${left}%{${varId}}${right}`;
-      setValues({ ...values, [selectedControl]: final });
     }
   };
 
@@ -883,12 +880,9 @@ const ModalPolicies = ({
                                   id='standard-subjectNotification'
                                   label='Subject'
                                   margin='normal'
-                                  onChange={handleChangeName(
-                                    'subjectNotification'
-                                  )}
-                                  onClick={() =>
-                                    setSelectedControl('subjectNotification')
-                                  }
+                                  name="subjectNotification"
+                                  onChange={handleChangeName('subjectNotification')}
+                                  onClick={setSelectedControlAndIndexes}
                                   value={values.subjectNotification}
                                 />
                               </div>
@@ -972,7 +966,9 @@ const ModalPolicies = ({
                                   id='standard-url'
                                   label='URL'
                                   margin='normal'
+                                  name="urlAPI"
                                   onChange={handleChangeName('urlAPI')}
+                                  onClick={setSelectedControlAndIndexes}
                                   style={{ width: '90%' }}
                                   value={values.urlAPI}
                                 />
@@ -1026,7 +1022,9 @@ const ModalPolicies = ({
                                 label='Body'
                                 margin='normal'
                                 multiline
+                                name="bodyAPI"
                                 onChange={handleChangeName('bodyAPI')}
+                                onClick={setSelectedControlAndIndexes}
                                 rows='4'
                                 style={{ width: '90%' }}
                                 value={values.bodyAPI}
@@ -1045,7 +1043,9 @@ const ModalPolicies = ({
                                 id='onLoad-URL'
                                 label='URL'
                                 margin='normal'
+                                name="urlOnLoad"
                                 onChange={handleChangeName('urlOnLoad')}
+                                onClick={setSelectedControlAndIndexes}
                                 style={{ width: '90%' }}
                                 value={values.urlOnLoad}
                               />

--- a/src/app/pages/home/Components/Policies/utils.js
+++ b/src/app/pages/home/Components/Policies/utils.js
@@ -84,19 +84,19 @@ export const executeOnLoadPolicy = async (itemID, module, selectedCatalogue, pol
   if (!onLoadDisabled) {
     if (tokenOnLoadEnabled) {
       try {
-        const { data: { response } } = await axios.get(urlOnLoad, {
+        const { data } = await axios.get(urlOnLoad, {
           headers: {
             Authorization: `Bearer ${tokenOnLoad}`,
           }
         });
-        res = handlePathResponse(response, onLoadFields);
+        res = handlePathResponse(data, onLoadFields);
       } catch (error) {
         console.log(error)
       }
     } else {
       try {
-        const { data: { response } } = await axios.get(urlOnLoad);
-        res = handlePathResponse(response, onLoadFields);
+        const { data } = await axios.get(urlOnLoad);
+        res = handlePathResponse(data, onLoadFields);
       } catch (error) {
         console.log(error);
       }
@@ -108,7 +108,7 @@ export const executeOnLoadPolicy = async (itemID, module, selectedCatalogue, pol
 
 const handlePathResponse = (response, onLoadFields, res = {}) => {
   Object.entries(onLoadFields).forEach((customField) => {
-    const pathResponse = objectPath.get(response, customField[1]);
+    const pathResponse = objectPath.get(response, customField[1], 'Not Found');
     res = { ...res, [customField[0]]: pathResponse };
   });
 

--- a/src/app/pages/home/constants.js
+++ b/src/app/pages/home/constants.js
@@ -112,6 +112,7 @@ export const CustomFieldsPreview = (props) => {
 
 export const allBaseFields = {
   userList: {
+    id: { validationId: 'userId', component: 'textField', compLabel: 'ID' },
     userProfile: {
       component: 'dropSelect',
       compLabel: 'Profile Selected',
@@ -136,13 +137,16 @@ export const allBaseFields = {
     }
   },
   userReferences: {
+    id: { validationId: 'userReferenceId', component: 'textField', compLabel: 'ID' },
     name: { validationId: 'name', component: 'textField', compLabel: 'Name' },
   },
   categories: {
+    id: { validationId: 'categoryId', component: 'textField', compLabel: 'ID' },
     name: { validationId: 'name', component: 'textField', compLabel: 'Name' },
     depreciation: { validationId: 'depreciation', component: 'textField', compLabel: 'Depreciation' },
   },
   references: {
+    id: { validationId: 'referenceId', component: 'textField', compLabel: 'ID' },
     category: { validationId: 'category', component: 'dropSelect', compLabel: 'Category' },
     name: { validationId: 'name', component: 'textField', compLabel: 'Name' },
     brand: { validationId: 'brand', component: 'textField', compLabel: 'Brand' },
@@ -151,6 +155,7 @@ export const allBaseFields = {
     depreciation: { validationId: 'depreciation', component: 'textField', compLabel: 'Depreciation' },
   },
   employees: {
+    id: { validationId: 'employeeId', component: 'textField', compLabel: 'ID' },
     employeeProfile: { validationId: 'employeeProfile', component: 'dropSelect', compLabel: 'Employee Profile' },
     name: { validationId: 'name', component: 'textField', compLabel: 'Name' },
     lastName: { validationId: 'lastName', component: 'textField', compLabel: 'Last Name' },
@@ -158,19 +163,23 @@ export const allBaseFields = {
     responsibilityLayout: { validationId: 'responsibilityLayout', component: 'dropSelect', compLabel: 'Responsibility Layout' },
   },
   employeeReferences: {
+    id: { validationId: 'employeeReferenceId', component: 'textField', compLabel: 'ID' },
     name: { validationId: 'name', component: 'textField', compLabel: 'Name' },
   },
   locations: {
+    id: { validationId: 'locationProfileId', component: 'textField', compLabel: 'ID' },
     selectedLevel: { validationId: 'selectedLevel', component: 'textField', compLabel: 'Level' },
     name: { validationId: 'name', component: 'textField', compLabel: 'Name' },
   },
   locationsList: {
+    id: { validationId: 'locationId', component: 'textField', compLabel: 'ID' },
     name: { validationId: 'name', component: 'textField', compLabel: 'Name' },
     fileExt: { validationId: 'fileExt', compLabel: 'Layout' },
     imageInfo: { validationId: 'imageInfo', compLabel: 'Pin Layout' },
     mapInfo: { validationId: 'mapInfo', compLabel: 'Pin Map' },
   },
   assets1: {
+    id: { validationId: 'assetId', component: 'textField', compLabel: 'ID' },
     name: { validationId: 'name', component: 'textField', compLabel: 'Name' },
     brand: { validationId: 'brand', component: 'textField', compLabel: 'Brand' },
     model: { validationId: 'model', component: 'textField', compLabel: 'Model' },


### PR DESCRIPTION
## General

This PR contains the corrections discussed in the post review sync with the client. These are the following bugs resolved in the modal of the policies.

- Cannot place base or custom fields on the text fields in any `message` `notifications` `API` `on load` tabs. Always a warning message pops up unless the html body in the messages tab is focused.
- Custom fields object path response was hardcoded.
- The base field `ID` was missing in all modules and catalogues.

### Before

![image](https://user-images.githubusercontent.com/57116943/118750926-0fe70b00-b826-11eb-9d76-7348cc2e3306.png)

![image](https://user-images.githubusercontent.com/57116943/118750999-2f7e3380-b826-11eb-9942-fa2d27974f01.png)

### After

![image](https://user-images.githubusercontent.com/57116943/118751067-4ae93e80-b826-11eb-84fd-254944cae922.png)

![image](https://user-images.githubusercontent.com/57116943/118751091-5472a680-b826-11eb-80ab-159ee3365abf.png)