### PR TITLE
Locations Fixes

### DIFF
--- a/src/app/pages/home/Components/Policies/utils.js
+++ b/src/app/pages/home/Components/Policies/utils.js
@@ -82,7 +82,7 @@ export const executeOnLoadPolicy = async (itemID, module, selectedCatalogue, pol
   let res;
 
   if (!onLoadDisabled) {
-    if (tokenOnLoadEnabled) {
+    if (tokenOnLoadEnabled) {      
       try {
         const { data } = await axios.get(urlOnLoad, {
           headers: {
@@ -102,7 +102,6 @@ export const executeOnLoadPolicy = async (itemID, module, selectedCatalogue, pol
       }
     }
   }
-
   return res;
 };
 

--- a/src/app/pages/home/Locations/Locations.js
+++ b/src/app/pages/home/Locations/Locations.js
@@ -75,6 +75,7 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
   const [loadingPreview, setLoadingPreview] = useState(false);
   const [loadingReset, setLoadingReset] = useState(false);
   const [locationsList, setLocationsList] = useState([]);
+  const [allLocationsProfiles, setAllLocationsProfiles] = useState([]);
   const [locationProfileRows, setLocationProfileRows] = useState([]);
   const [locationsTree, setLocationsTree] = useState({});
   const [mapCenter, setMapCenter] = useState({ lat: 19.432608, lng: -99.133209 });
@@ -342,6 +343,21 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
   };
 
   const handleLoadLocations = () => {
+
+    if (!Object.entries(locationsTree).length) {
+      getDB('locations')
+        .then((response) => response.json())
+        .then((data) => {
+          const profileRows = data.response.map((row) => {
+            const { _id, level, name, creationUserFullName, creationDate } = row;
+            const date = utcToZonedTime(creationDate).toLocaleString();
+            return createLocationProfileRow(_id, level, name, creationUserFullName, date);
+          });
+          setAllLocationsProfiles(profileRows);
+        })
+        .catch((error) => console.log(error));
+    }
+
     setLocationsTree({});
     getDB('locationsReal')
       .then((response) => response.json())
@@ -434,7 +450,7 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
     getSelfCenter(parent);
     setParentSelected(parent);
     setRealParentSelected(realParent);
-    let locationProf = locationProfileRows.filter((row) => row.level == lvl);
+    let locationProf = allLocationsProfiles.filter((row) => row.level === lvl);
     setSelectedLocationProfileRows(locationProf);
   };
 

--- a/src/app/pages/home/Locations/Locations.js
+++ b/src/app/pages/home/Locations/Locations.js
@@ -254,11 +254,12 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
               dispatch(showDeletedAlert());
               executePolicies('OnDelete', 'locations', 'profiles', data.response);
               loadLocationsProfilesData();
+              updateGeneralProfileLocations();
             })
             .catch((_) => dispatch(showErrorAlert()));
         });
-      })
-        .catch((_) => dispatch(showErrorAlert())));
+      }))
+      .catch((_) => dispatch(showErrorAlert()));
   };
 
   const onEditProfileLocation = (_id) => {
@@ -345,17 +346,7 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
   const handleLoadLocations = () => {
 
     if (!Object.entries(locationsTree).length) {
-      getDB('locations')
-        .then((response) => response.json())
-        .then((data) => {
-          const profileRows = data.response.map((row) => {
-            const { _id, level, name, creationUserFullName, creationDate } = row;
-            const date = utcToZonedTime(creationDate).toLocaleString();
-            return createLocationProfileRow(_id, level, name, creationUserFullName, date);
-          });
-          setAllLocationsProfiles(profileRows);
-        })
-        .catch((error) => console.log(error));
+      updateGeneralProfileLocations();
     }
 
     setLocationsTree({});
@@ -387,6 +378,20 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
       searchBy: '',
     },
   });
+
+  const updateGeneralProfileLocations = () => {
+    getDB('locations')
+      .then((response) => response.json())
+      .then((data) => {
+        const profileRows = data.response.map((row) => {
+          const { _id, level, name, creationUserFullName, creationDate } = row;
+          const date = utcToZonedTime(creationDate).toLocaleString();
+          return createLocationProfileRow(_id, level, name, creationUserFullName, date);
+        });
+        setAllLocationsProfiles(profileRows);
+      })
+      .catch((error) => console.log(error));
+  };
 
   const loadLocationsProfilesData = (collectionNames = ['locations']) => {
     collectionNames = !Array.isArray(collectionNames) ? [collectionNames] : collectionNames;
@@ -450,7 +455,7 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
     getSelfCenter(parent);
     setParentSelected(parent);
     setRealParentSelected(realParent);
-    let locationProf = allLocationsProfiles.filter((row) => row.level === lvl);
+    let locationProf = allLocationsProfiles.filter((row) => row.level === lvl || row.level === lvl?.toString());
     setSelectedLocationProfileRows(locationProf);
   };
 
@@ -670,6 +675,7 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
                           reloadTable={loadLocationsProfilesData}
                           setShowModal={setOpenProfileModal}
                           showModal={openProfileModal}
+                          updateGeneralProfileLocations={updateGeneralProfileLocations}
                         />
 
                         <div className='kt-separator kt-separator--dashed' />

--- a/src/app/pages/home/Locations/Locations.js
+++ b/src/app/pages/home/Locations/Locations.js
@@ -132,9 +132,9 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
               executePolicies('OnDelete', 'locations', 'list', data.response);
               handleLoadLocations();
             })
-            .catch((_) => dispatch(showErrorAlert()));
+            .catch((error) => dispatch(showErrorAlert()));
         })
-        .catch((_) => dispatch(showErrorAlert()));
+        .catch((error) => dispatch(showErrorAlert()));
       setOpenYesNoModal(false);
     },
     openProfilesListBox(e) {
@@ -256,10 +256,10 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
               loadLocationsProfilesData();
               updateGeneralProfileLocations();
             })
-            .catch((_) => dispatch(showErrorAlert()));
+            .catch((error) => dispatch(showErrorAlert()));
         });
       }))
-      .catch((_) => dispatch(showErrorAlert()));
+      .catch((error) => dispatch(showErrorAlert()));
   };
 
   const onEditProfileLocation = (_id) => {
@@ -390,7 +390,7 @@ const Locations = ({ globalSearch, setGeneralSearch, user }) => {
         });
         setAllLocationsProfiles(profileRows);
       })
-      .catch((error) => console.log(error));
+      .catch((error) => dispatch(showErrorAlert()));
   };
 
   const loadLocationsProfilesData = (collectionNames = ['locations']) => {

--- a/src/app/pages/home/Locations/modals/ModalLocationList.js
+++ b/src/app/pages/home/Locations/modals/ModalLocationList.js
@@ -277,7 +277,7 @@ const ModalLocationList = ({
   };
 
   useEffect(() => {
-    if (!profile || !profile.id || editOrNew === 'edit' || !showModal || parent === 'root') {
+    if (!profile || !profile.id || editOrNew === 'edit' || !showModal) {
       return;
     }
     getOneDB('locations/', profile.id)
@@ -289,7 +289,6 @@ const ModalLocationList = ({
           level: profileLevel,
           customFieldsTab
         } = data.response;
-        // executePolicies('OnLoad', 'locations', 'list', policies);
         setValues((prev) => ({ ...prev, name: '', profileName, profileId, profileLevel, customFieldsTab }));
         setProfileLabel(profile.name);
         const tabs = Object.keys(customFieldsTab).map((key) => ({
@@ -304,7 +303,7 @@ const ModalLocationList = ({
     getOneDB('locationsReal/', parent)
       .then((response) => response.json())
       .then((data) => {
-        const { fileExt } = data.response;
+        const fileExt = data.response?.fileExt;
         const imageURL = parent !== "root" ? getImageURL(parent, 'locationsReal', fileExt) : '';
         setValues((prev) => ({ ...prev, imageURL }));
       })

--- a/src/app/pages/home/Locations/modals/ModalLocationProfiles.js
+++ b/src/app/pages/home/Locations/modals/ModalLocationProfiles.js
@@ -188,7 +188,7 @@ const ModalLocationProfiles = ({ showModal, setShowModal, reloadTable, id, polic
 
     const fileExt = getFileExtension(image);
     const body = { ...values, customFieldsTab, fileExt };
-    console.log('isNew:', isNew)
+    
     if (isNew) {
       postDB('locations', body)
         .then(data => data.json())

--- a/src/app/pages/home/Locations/modals/ModalLocationProfiles.js
+++ b/src/app/pages/home/Locations/modals/ModalLocationProfiles.js
@@ -241,18 +241,20 @@ const ModalLocationProfiles = ({ showModal, setShowModal, reloadTable, id, polic
     getOneDB('locations/', id[0])
       .then(response => response.json())
       .then(data => {
-        const { name, level, isAssetRepository, isLocationControl, customFieldsTab, fileExt } = data.response;
-        const obj = {
-          name,
-          level,
-          isAssetRepository: isAssetRepository || false,
-          isLocationControl: isLocationControl || false,
-          imageURL: getImageURL(id, 'locations', fileExt)
-        };
-        executePolicies('OnLoad', 'locations', 'profiles', policies);
-        setValues(obj);
-        setCustomFieldsTab(customFieldsTab);
-        setIsNew(false);
+        if (data.response) {
+          const { name, level, isAssetRepository, isLocationControl, customFieldsTab, fileExt } = data.response;
+          const obj = {
+            name,
+            level,
+            isAssetRepository: isAssetRepository || false,
+            isLocationControl: isLocationControl || false,
+            imageURL: getImageURL(id, 'locations', fileExt)
+          };
+          executePolicies('OnLoad', 'locations', 'profiles', policies);
+          setValues(obj);
+          setCustomFieldsTab(customFieldsTab);
+          setIsNew(false);
+        }
       })
       .catch(error => dispatch(showErrorAlert()));
   }, [id]);

--- a/src/app/pages/home/Locations/modals/ModalLocationProfiles.js
+++ b/src/app/pages/home/Locations/modals/ModalLocationProfiles.js
@@ -120,7 +120,7 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-const ModalLocationProfiles = ({ showModal, setShowModal, reloadTable, id, policies }) => {
+const ModalLocationProfiles = ({ showModal, setShowModal, reloadTable, id, policies, updateGeneralProfileLocations }) => {
   const dispatch = useDispatch();
   const { showFillFieldsAlert, showErrorAlert, showSavedAlert, showUpdatedAlert } = actions;
   // Example 4 - Tabs
@@ -197,6 +197,7 @@ const ModalLocationProfiles = ({ showModal, setShowModal, reloadTable, id, polic
           const { _id } = response.response[0];
           saveAndReload('locations', _id);
           executePolicies('OnAdd', 'locations', 'profiles', policies);
+          updateGeneralProfileLocations();
         })
         .catch(error => dispatch(showErrorAlert()));
     } else {
@@ -205,6 +206,7 @@ const ModalLocationProfiles = ({ showModal, setShowModal, reloadTable, id, polic
           dispatch(showUpdatedAlert());
           saveAndReload('locations', id[0]);
           executePolicies('OnEdit', 'locations', 'profiles', policies);
+          updateGeneralProfileLocations();
         })
         .catch(error => dispatch(showErrorAlert()));
     }


### PR DESCRIPTION
## General
This PR contains major fixes in the `Locations` module.

- When adding a new location, the pagination in the profiles tab caused the profile selector to only show the only ones showed in the table.
- A minor bug was caused when editing a profile and delete it afterwards.
- When adding a new location of level 0, it profile information was unreadable and causes to not showing the new location in the tree.

### Before

![image](https://user-images.githubusercontent.com/57116943/119911833-ba92b400-bf1f-11eb-96de-42c4609dae2a.png)
![image](https://user-images.githubusercontent.com/57116943/119911876-e1e98100-bf1f-11eb-94fe-45b0f8e9b2c4.png)

### After

![image](https://user-images.githubusercontent.com/57116943/119911847-c4b4b280-bf1f-11eb-95b8-e8ddabd58f05.png)
![image](https://user-images.githubusercontent.com/57116943/119911898-ee6dd980-bf1f-11eb-8f37-7e52d0b66343.png)
